### PR TITLE
Avoid long lines in examples

### DIFF
--- a/examples/bfv/examples_bfv.go
+++ b/examples/bfv/examples_bfv.go
@@ -19,26 +19,30 @@ var bfvContext *bfv.BfvContext
 
 func ObliviousRiding() {
 
-	// This example will simulate a situation where an anonymous rider wants to find the closest available rider within a given area.
+	// This example will simulate a situation where an anonymous rider wants to find the closest available rider within
+	// a given area.
 	// The application is inspired by the paper https://oride.epfl.ch/
 	//
-	// 		A. Pham, I. Dacosta, G. Endignoux, J. Troncoso-Pastoriza, K. Huguenin, and J.-P. Hubaux. ORide: A Privacy-Preserving yet Accountable Ride-Hailing Service.
+	// 		A. Pham, I. Dacosta, G. Endignoux, J. Troncoso-Pastoriza, K. Huguenin, and J.-P. Hubaux.
+	// 		ORide: A Privacy-Preserving yet Accountable Ride-Hailing Service.
 	//		In Proceedings of the 26th USENIX Security Symposium, Vancouver, BC, Canada, August 2017.
 	//
-	// Each area is represented as a rectangular grid where each driver reports his coordinates in real time to a server assigned to the area.
+	// Each area is represented as a rectangular grid where each driver reports his coordinates in real time to a server
+	// assigned to the area.
 	//
-	// First, the rider generates an ephemeral key pair (sk, pk), which he uses to encrypt his coordinates. He then sends the tuple (pk, enc(coordinates)) to the
-	// server handling the area he is in.
+	// First, the rider generates an ephemeral key pair (sk, pk), which he uses to encrypt his coordinates.
+	// He then sends the tuple (pk, enc(coordinates)) to the server handling the area he is in.
 	//
-	// Once the public key and the encrypted rider coordinates of the rider have been received by the server, the rider's public key is
-	// transferred to all the drivers within the area, with a randomized different index for each of them, that indicates in which coefficient each driver must
-	// encode his coordinates.
+	// Once the public key and the encrypted rider coordinates of the rider have been received by the server,
+	// the rider's public key is transferred to all the drivers within the area, with a randomized different index for
+	// each of them, that indicates in which coefficient each driver must encode his coordinates.
 	//
-	// Each driver encodes his coordinates in the designated coefficient and uses the received public key to encrypt his encoded coordinates.
-	// He then sends back the encrypted coordinates to the server.
+	// Each driver encodes his coordinates in the designated coefficient and uses the received public key to encrypt his
+	// encoded coordinates. He then sends back the encrypted coordinates to the server.
 	//
-	// Once the encrypted coordinates of the drivers have been received, the server homomorphically computes the squared distance: (x0 - x1)^2 + (y0 - y1)^2 between
-	// the rider and each of the drivers, and sends back the encrypted result to the rider.
+	// Once the encrypted coordinates of the drivers have been received, the server homomorphically computes the
+	// squared distance: (x0 - x1)^2 + (y0 - y1)^2 between the rider and each of the drivers,
+	// and sends back the encrypted result to the rider.
 	//
 	// The rider decrypts the result and chooses the closest driver.
 
@@ -87,13 +91,15 @@ func ObliviousRiding() {
 	fmt.Println("Homomorphic computations on batched integers")
 	fmt.Println("============================================")
 	fmt.Println()
-	fmt.Printf("Parameters : N=%d, T=%d, logQ = %d (%d limbs), sigma = %f \n", bfvContext.N(), bfvContext.T(), bfvContext.LogQ(), len(params.Qi), bfvContext.Sigma())
+	fmt.Printf("Parameters : N=%d, T=%d, logQ = %d (%d limbs), sigma = %f \n",
+		bfvContext.N(), bfvContext.T(), bfvContext.LogQ(), len(params.Qi), bfvContext.Sigma())
 	fmt.Println()
 
 	maxvalue := uint64(math.Sqrt(float64(params.T))) // max values = floor(sqrt(plaintext modulus))
 	mask := uint64(1<<uint64(bits.Len64(maxvalue))) - 1
 
-	fmt.Printf("Generating %d Drivers and 1 Rider randomly positioned on a grid of %d x %d units \n", NbDrivers, maxvalue, maxvalue)
+	fmt.Printf("Generating %d Drivers and 1 Rider randomly positioned on a grid of %d x %d units \n",
+		NbDrivers, maxvalue, maxvalue)
 	fmt.Println()
 
 	Drivers := make([][]uint64, params.N>>1)
@@ -123,7 +129,8 @@ func ObliviousRiding() {
 		batchEncoder.EncodeUint(Drivers[i], DriversPlaintexts[i])
 	}
 
-	fmt.Printf("Encrypting %d Drivers (x, y) and 1 Rider (%d, %d) \n", NbDrivers, riderposition[0], riderposition[1])
+	fmt.Printf("Encrypting %d Drivers (x, y) and 1 Rider (%d, %d) \n",
+		NbDrivers, riderposition[0], riderposition[1])
 	fmt.Println()
 
 	RiderCiphertext, err := EncryptorSk.EncryptNew(RiderPlaintext)
@@ -177,7 +184,8 @@ func ObliviousRiding() {
 		}
 
 		if i < 4 || i > NbDrivers-5 {
-			fmt.Printf("Distance with Driver %d : %8d = (%4d - %4d)^2 + (%4d - %4d)^2: %t \n", i, r1, Drivers[i][i<<1], Rider[0], Drivers[i][(i<<1)+1], Rider[1], r1 == r1exp)
+			fmt.Printf("Distance with Driver %d : %8d = (%4d - %4d)^2 + (%4d - %4d)^2: %t \n",
+				i, r1, Drivers[i][i<<1], Rider[0], Drivers[i][(i<<1)+1], Rider[1], r1 == r1exp)
 		}
 
 		if i == NbDrivers>>1 {
@@ -191,7 +199,8 @@ func ObliviousRiding() {
 
 	fmt.Println()
 
-	fmt.Printf("Closest Driver to Rider is n°%d (%d, %d) with a distance of %d units \n", closest[0], closest[1], closest[2], uint64(math.Sqrt(float64(closest[3]))))
+	fmt.Printf("Closest Driver to Rider is n°%d (%d, %d) with a distance of %d units \n",
+		closest[0], closest[1], closest[2], uint64(math.Sqrt(float64(closest[3]))))
 }
 
 func Distance(a, b, c, d uint64) uint64 {

--- a/examples/ckks/examples_ckks.go
+++ b/examples/ckks/examples_ckks.go
@@ -22,7 +22,8 @@ func randomComplex(min, max float64) complex128 {
 
 func chebyshevinterpolation() {
 
-	// This example will pack random 8192 float64 values in the range [-8, 8] and approximate the function 1/(exp(-x) + 1) over the range [-8, 8].
+	// This example will pack random 8192 float64 values in the range [-8, 8] and approximate
+	// the function 1/(exp(-x) + 1) over the range [-8, 8].
 	// The result is then parsed and compared to the expected result.
 
 	rand.Seed(time.Now().UnixNano())
@@ -76,10 +77,12 @@ func chebyshevinterpolation() {
 		values[i] = complex(randomFloat(-8, 8), 0)
 	}
 
-	fmt.Printf("HEAAN parameters : logN = %d, logQ = %d, levels = %d, logScale = %d, sigma = %f \n", ckkscontext.LogN(), ckkscontext.LogQ(), ckkscontext.Levels(), ckkscontext.Scale(), ckkscontext.Sigma())
+	fmt.Printf("HEAAN parameters : logN = %d, logQ = %d, levels = %d, logScale = %d, sigma = %f \n",
+		ckkscontext.LogN(), ckkscontext.LogQ(), ckkscontext.Levels(), ckkscontext.Scale(), ckkscontext.Sigma())
 
 	fmt.Println()
-	fmt.Printf("Values     : %6f %6f %6f %6f...\n", round(values[0]), round(values[1]), round(values[2]), round(values[3]))
+	fmt.Printf("Values     : %6f %6f %6f %6f...\n",
+		round(values[0]), round(values[1]), round(values[2]), round(values[3]))
 	fmt.Println()
 
 	// Plaintext creation and encoding process
@@ -97,9 +100,11 @@ func chebyshevinterpolation() {
 	fmt.Println("Evaluation of the function 1/(exp(-x)+1) in the range [-8, 8] (degree of approximation : 32)")
 
 	// Evaluation process
-	chebyapproximation := ckks.Approximate(f, -8, 8, 33) // We ask to approximate f(x) in the range [-8, 8] with a chebyshev polynomial of 33 coefficients (degree 32).
+	chebyapproximation := ckks.Approximate(f, -8, 8, 33) // We ask to approximate f(x) in
+	// the range [-8, 8] with a chebyshev polynomial of 33 coefficients (degree 32).
 
-	if ciphertext, err = evaluator.EvaluateCheby(ciphertext, chebyapproximation, rlk); err != nil { // We evaluate the interpolated chebyshev polynomial on the ciphertext
+	if ciphertext, err = evaluator.EvaluateCheby(ciphertext, chebyapproximation, rlk); err != nil {
+		// We evaluate the interpolated chebyshev polynomial on the ciphertext
 		log.Fatal(err)
 	}
 
@@ -115,8 +120,10 @@ func chebyshevinterpolation() {
 
 	// Printing results and comparison
 	fmt.Println()
-	fmt.Printf("ValuesTest : %6f %6f %6f %6f...\n", round(valuesTest[0]), round(valuesTest[1]), round(valuesTest[2]), round(valuesTest[3]))
-	fmt.Printf("ValuesWant : %6f %6f %6f %6f...\n", round(values[0]), round(values[1]), round(values[2]), round(values[3]))
+	fmt.Printf("ValuesTest : %6f %6f %6f %6f...\n",
+		round(valuesTest[0]), round(valuesTest[1]), round(valuesTest[2]), round(valuesTest[3]))
+	fmt.Printf("ValuesWant : %6f %6f %6f %6f...\n",
+		round(values[0]), round(values[1]), round(values[2]), round(values[3]))
 	verify_vector(values, valuesTest)
 
 }
@@ -185,10 +192,14 @@ func verify_vector(valuesWant, valuesTest []complex128) (err error) {
 	medianprec = calcmedian(diff)
 
 	fmt.Println()
-	fmt.Printf("Minimum precision : (%.2f, %.2f) bits \n", math.Log2(1/real(minprec)), math.Log2(1/imag(minprec)))
-	fmt.Printf("Maximum precision : (%.2f, %.2f) bits \n", math.Log2(1/real(maxprec)), math.Log2(1/imag(maxprec)))
-	fmt.Printf("Mean    precision : (%.2f, %.2f) bits \n", math.Log2(1/real(meanprec)), math.Log2(1/imag(meanprec)))
-	fmt.Printf("Median  precision : (%.2f, %.2f) bits \n", math.Log2(1/real(medianprec)), math.Log2(1/imag(medianprec)))
+	fmt.Printf("Minimum precision : (%.2f, %.2f) bits \n",
+		math.Log2(1/real(minprec)), math.Log2(1/imag(minprec)))
+	fmt.Printf("Maximum precision : (%.2f, %.2f) bits \n",
+		math.Log2(1/real(maxprec)), math.Log2(1/imag(maxprec)))
+	fmt.Printf("Mean    precision : (%.2f, %.2f) bits \n",
+		math.Log2(1/real(meanprec)), math.Log2(1/imag(meanprec)))
+	fmt.Printf("Median  precision : (%.2f, %.2f) bits \n",
+		math.Log2(1/real(medianprec)), math.Log2(1/imag(medianprec)))
 	fmt.Println()
 
 	return nil


### PR DESCRIPTION
Some lines are very long, making them hard to read on GitHub

<img width="893" alt="Screenshot 2019-10-04 at 09 58 58" src="https://user-images.githubusercontent.com/9142800/66191024-9bca1480-e68d-11e9-8dda-b4764d9e78d0.png">
