### PR TITLE
UnmarshalBinary on an uninitialized Ciphertext triggers nil pointer dereference

### DIFF
--- a/bfv/bfv_test.go
+++ b/bfv/bfv_test.go
@@ -186,13 +186,22 @@ func test_Marshaler(bfvTest *BFVTESTPARAMS, t *testing.T) {
 			t.Error(err)
 		}
 
+		ctTestNew := new(Ciphertext)
+		err = ctTestNew.UnMarshalBinary(CtxBytes)
+		if err != nil {
+			t.Error(err)
+		}
+
 		for i := range Ctx.Value() {
-			if bfvContext.contextQ.Equal(CtxTest.Value()[i], Ctx.Value()[i]) != true {
-				t.Errorf("error : binarymarshal ciphertext")
+			if bfvContext.contextQ.Equal(CtxTest.Value()[i], Ctx.Value()[i]) {
+				t.Error("pre-allocated unmarshalled ciphertext not matching marshalled one")
+				break
+			}
+			if bfvContext.contextQ.Equal(ctTestNew.Value()[i], Ctx.Value()[i]) {
+				t.Error("unmarshalled ciphertext not matching marshalled one")
 				break
 			}
 		}
-
 	})
 
 	t.Run(fmt.Sprintf("N=%d/T=%d/Qi=%dlimbs/bitDecomp=%d/Marshalrlk", bfvTest.bfvcontext.n,


### PR DESCRIPTION
It should be possible to create valid Ciphertext structs without having to allocate them from the BfvContext.

This is useful when the user code delegates such tasks to other libraries, such as a network library, which shouldn't have to be aware of the context.