### PR TITLE
update `equalslice` functions to use constant time comparison

### DIFF
--- a/bfv/utils.go
+++ b/bfv/utils.go
@@ -7,12 +7,11 @@ func equalslice(a, b []uint64) bool {
 		return false
 	}
 
+	v := true
 	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
+		v = v && (a[i] == b[i])
 	}
-	return true
+	return v
 }
 
 // min returns the minimum value of the input slice of uint64 values.

--- a/ckks/utils.go
+++ b/ckks/utils.go
@@ -2,10 +2,11 @@ package ckks
 
 import (
 	"errors"
-	"github.com/ldsec/lattigo/ring"
 	"math"
 	"math/big"
 	"math/bits"
+
+	"github.com/ldsec/lattigo/ring"
 )
 
 // Multiplies x by 2^n and returns the result mod q
@@ -123,13 +124,11 @@ func equalslice64(a, b []uint64) bool {
 		return false
 	}
 
+	v := true
 	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
+		v = v && (a[i] == b[i])
 	}
-
-	return true
+	return v
 }
 
 func equalslice8(a, b []uint8) bool {
@@ -138,13 +137,11 @@ func equalslice8(a, b []uint8) bool {
 		return false
 	}
 
+	v := true
 	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
+		v = v && (a[i] == b[i])
 	}
-
-	return true
+	return v
 }
 
 func min(values []uint64) (r uint64) {

--- a/dbfv/utils.go
+++ b/dbfv/utils.go
@@ -7,10 +7,9 @@ func equalslice(a, b []uint64) bool {
 		return false
 	}
 
+	v := true
 	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
+		v = v && (a[i] == b[i])
 	}
-	return true
+	return v
 }


### PR DESCRIPTION
This is a PR for a small refactor to `equalslice` functions to use a constant time comparison similar to that found in the `subtle` library.

This allows for two slices, a and b, to always return at the same response rate as a successful comparison. 