### PR TITLE
change Encryptor to an interface

### DIFF
--- a/bfv/bfv_test.go
+++ b/bfv/bfv_test.go
@@ -32,7 +32,7 @@ type bfvParams struct {
 	encryptorPk Encryptor
 	encryptorSk Encryptor
 	decryptor   Decryptor
-	evaluator   *Evaluator
+	evaluator   Evaluator
 }
 
 type bfvTestParameters struct {

--- a/bfv/bfv_test.go
+++ b/bfv/bfv_test.go
@@ -31,7 +31,7 @@ type bfvParams struct {
 	pk          *PublicKey
 	encryptorPk Encryptor
 	encryptorSk Encryptor
-	decryptor   *Decryptor
+	decryptor   Decryptor
 	evaluator   *Evaluator
 }
 
@@ -280,7 +280,7 @@ func newTestVectors(params *bfvParams, encryptor Encryptor, t *testing.T) (coeff
 	return coeffs, plaintext, ciphertext
 }
 
-func verifyTestVectors(params *bfvParams, decryptor *Decryptor, coeffs *ring.Poly, element Operand, t *testing.T) {
+func verifyTestVectors(params *bfvParams, decryptor Decryptor, coeffs *ring.Poly, element Operand, t *testing.T) {
 
 	var coeffsTest []uint64
 

--- a/bfv/bfv_test.go
+++ b/bfv/bfv_test.go
@@ -25,7 +25,7 @@ func testString(opname string, params *Parameters) string {
 type bfvParams struct {
 	params      *Parameters
 	bfvContext  *bfvContext
-	encoder     *Encoder
+	encoder     Encoder
 	kgen        *KeyGenerator
 	sk          *SecretKey
 	pk          *PublicKey

--- a/bfv/bfv_test.go
+++ b/bfv/bfv_test.go
@@ -2,12 +2,13 @@ package bfv
 
 import (
 	"fmt"
-	"github.com/ldsec/lattigo/ring"
-	"github.com/ldsec/lattigo/utils"
 	"log"
 	"math/rand"
 	"testing"
 	"time"
+
+	"github.com/ldsec/lattigo/ring"
+	"github.com/ldsec/lattigo/utils"
 )
 
 func check(t *testing.T, err error) {
@@ -28,8 +29,8 @@ type bfvParams struct {
 	kgen        *KeyGenerator
 	sk          *SecretKey
 	pk          *PublicKey
-	encryptorPk *Encryptor
-	encryptorSk *Encryptor
+	encryptorPk Encryptor
+	encryptorSk Encryptor
 	decryptor   *Decryptor
 	evaluator   *Evaluator
 }
@@ -264,7 +265,7 @@ func genBfvParams(contextParameters *Parameters) (params *bfvParams) {
 
 }
 
-func newTestVectors(params *bfvParams, encryptor *Encryptor, t *testing.T) (coeffs *ring.Poly, plaintext *Plaintext, ciphertext *Ciphertext) {
+func newTestVectors(params *bfvParams, encryptor Encryptor, t *testing.T) (coeffs *ring.Poly, plaintext *Plaintext, ciphertext *Ciphertext) {
 
 	coeffs = params.bfvContext.contextT.NewUniformPoly()
 

--- a/bfv/bfv_test.go
+++ b/bfv/bfv_test.go
@@ -26,7 +26,7 @@ type bfvParams struct {
 	params      *Parameters
 	bfvContext  *bfvContext
 	encoder     Encoder
-	kgen        *KeyGenerator
+	kgen        KeyGenerator
 	sk          *SecretKey
 	pk          *PublicKey
 	encryptorPk Encryptor

--- a/bfv/decryptor.go
+++ b/bfv/decryptor.go
@@ -4,17 +4,28 @@ import (
 	"github.com/ldsec/lattigo/ring"
 )
 
-// Decryptor is a structure used to decrypt ciphertexts. It stores the secret-key.
-type Decryptor struct {
+// Decryptor is an interface for decryptors
+type Decryptor interface {
+	// DecryptNew decrypts the input ciphertext and returns the result on a new
+	// plaintext.
+	DecryptNew(ciphertext *Ciphertext) *Plaintext
+
+	// Decrypt decrypts the input ciphertext and returns the result on the
+	// provided receiver plaintext.
+	Decrypt(ciphertext *Ciphertext, plaintext *Plaintext)
+}
+
+// decryptor is a structure used to decrypt ciphertexts. It stores the secret-key.
+type decryptor struct {
 	params     *Parameters
 	bfvContext *bfvContext
 	sk         *SecretKey
 	polypool   *ring.Poly
 }
 
-// NewDecryptor creates a new Decryptor from the target context with the secret-key given as input.
-func NewDecryptor(params *Parameters, sk *SecretKey) (decryptor *Decryptor) {
-
+// NewDecryptor creates a new Decryptor from the parameters with the secret-key
+// given as input.
+func NewDecryptor(params *Parameters, sk *SecretKey) Decryptor {
 	if !params.isValid {
 		panic("cannot NewDecryptor: params not valid (check if they were generated properly)")
 	}
@@ -23,32 +34,25 @@ func NewDecryptor(params *Parameters, sk *SecretKey) (decryptor *Decryptor) {
 		panic("cannot NewDecryptor: secret_key degree must match context degree")
 	}
 
-	decryptor = new(Decryptor)
+	ctx := newBFVContext(params)
 
-	decryptor.params = params.Copy()
-
-	decryptor.bfvContext = newBFVContext(params)
-
-	decryptor.sk = sk
-
-	decryptor.polypool = decryptor.bfvContext.contextQ.NewPoly()
-
-	return decryptor
+	return &decryptor{
+		params:     params.Copy(),
+		bfvContext: ctx,
+		sk:         sk,
+		polypool:   ctx.contextQ.NewPoly(),
+	}
 }
 
-// DecryptNew decrypts the input ciphertext and returns the result on a new plaintext.
-func (decryptor *Decryptor) DecryptNew(ciphertext *Ciphertext) (plaintext *Plaintext) {
-
-	plaintext = NewPlaintext(decryptor.params)
+func (decryptor *decryptor) DecryptNew(ciphertext *Ciphertext) *Plaintext {
+	plaintext := NewPlaintext(decryptor.params)
 
 	decryptor.Decrypt(ciphertext, plaintext)
 
-	return
+	return plaintext
 }
 
-// Decrypt decrypts the input ciphertext and returns the result on the provided receiver plaintext.
-func (decryptor *Decryptor) Decrypt(ciphertext *Ciphertext, plaintext *Plaintext) {
-
+func (decryptor *decryptor) Decrypt(ciphertext *Ciphertext, plaintext *Plaintext) {
 	ringContext := decryptor.bfvContext.contextQ
 
 	ringContext.NTT(ciphertext.value[ciphertext.Degree()], plaintext.value)

--- a/bfv/encoder.go
+++ b/bfv/encoder.go
@@ -6,8 +6,16 @@ import (
 	"math/bits"
 )
 
+// Encoder is an interface implementing the encoder.
+type Encoder interface {
+	EncodeUint(coeffs []uint64, plaintext *Plaintext)
+	EncodeInt(coeffs []int64, plaintext *Plaintext)
+	DecodeUint(plaintext *Plaintext) (coeffs []uint64)
+	DecodeInt(plaintext *Plaintext) (coeffs []int64)
+}
+
 // Encoder is a structure that stores the parameters to encode values on a plaintext in a SIMD (Single-Instruction Multiple-Data) fashion.
-type Encoder struct {
+type encoder struct {
 	params       *Parameters
 	bfvContext   *bfvContext
 	indexMatrix  []uint64
@@ -17,27 +25,24 @@ type Encoder struct {
 }
 
 // NewEncoder creates a new encoder from the provided parameters.
-func NewEncoder(params *Parameters) (encoder *Encoder) {
+func NewEncoder(params *Parameters) Encoder {
 
 	if !params.isValid {
 		panic("cannot NewEncoder: params not valid (check if they were generated properly)")
 	}
 
+	bfvContext := newBFVContext(params)
+
 	var m, pos, index1, index2 uint64
 
-	encoder = new(Encoder)
+	slots := bfvContext.n
 
-	encoder.params = params.Copy()
-	encoder.bfvContext = newBFVContext(params)
+	indexMatrix := make([]uint64, slots)
 
-	slots := encoder.bfvContext.n
+	logN := uint64(bits.Len64(bfvContext.n) - 1)
 
-	encoder.indexMatrix = make([]uint64, slots)
-
-	logN := uint64(bits.Len64(encoder.bfvContext.n) - 1)
-
-	rowSize := encoder.bfvContext.n >> 1
-	m = (encoder.bfvContext.n << 1)
+	rowSize := bfvContext.n >> 1
+	m = (bfvContext.n << 1)
 	pos = 1
 
 	for i := uint64(0); i < rowSize; i++ {
@@ -45,23 +50,25 @@ func NewEncoder(params *Parameters) (encoder *Encoder) {
 		index1 = (pos - 1) >> 1
 		index2 = (m - pos - 1) >> 1
 
-		encoder.indexMatrix[i] = utils.BitReverse64(index1, logN)
-		encoder.indexMatrix[i|rowSize] = utils.BitReverse64(index2, logN)
+		indexMatrix[i] = utils.BitReverse64(index1, logN)
+		indexMatrix[i|rowSize] = utils.BitReverse64(index2, logN)
 
 		pos *= GaloisGen
 		pos &= (m - 1)
 	}
 
-	encoder.deltaMont = GenLiftParams(encoder.bfvContext.contextQ, params.T)
-
-	encoder.simplescaler = ring.NewSimpleScaler(params.T, encoder.bfvContext.contextQ)
-	encoder.polypool = encoder.bfvContext.contextT.NewPoly()
-
-	return encoder
+	return &encoder{
+		params:       params.Copy(),
+		bfvContext:   bfvContext,
+		indexMatrix:  indexMatrix,
+		deltaMont:    GenLiftParams(bfvContext.contextQ, params.T),
+		simplescaler: ring.NewSimpleScaler(params.T, bfvContext.contextQ),
+		polypool:     bfvContext.contextT.NewPoly(),
+	}
 }
 
 // EncodeUint encodes an uint64 slice of size at most N on a plaintext.
-func (encoder *Encoder) EncodeUint(coeffs []uint64, plaintext *Plaintext) {
+func (encoder *encoder) EncodeUint(coeffs []uint64, plaintext *Plaintext) {
 
 	if len(coeffs) > len(encoder.indexMatrix) {
 		panic("cannot EncodeUint: invalid input to encode (number of coefficients must be smaller or equal to the context)")
@@ -85,7 +92,7 @@ func (encoder *Encoder) EncodeUint(coeffs []uint64, plaintext *Plaintext) {
 
 // EncodeInt encodes an int64 slice of size at most N on a plaintext. It also encodes the sign of the given integer (as its inverse modulo the plaintext modulus).
 // The sign will correctly decode as long as the absolute value of the coefficient does not exceed half of the plaintext modulus.
-func (encoder *Encoder) EncodeInt(coeffs []int64, plaintext *Plaintext) {
+func (encoder *encoder) EncodeInt(coeffs []int64, plaintext *Plaintext) {
 
 	if len(coeffs) > len(encoder.indexMatrix) {
 		panic("cannot EncodeInt: invalid input to encode (number of coefficients must be smaller or equal to the context)")
@@ -111,7 +118,7 @@ func (encoder *Encoder) EncodeInt(coeffs []int64, plaintext *Plaintext) {
 	encoder.encodePlaintext(plaintext)
 }
 
-func (encoder *Encoder) encodePlaintext(p *Plaintext) {
+func (encoder *encoder) encodePlaintext(p *Plaintext) {
 
 	encoder.bfvContext.contextT.InvNTT(p.value, p.value)
 
@@ -130,7 +137,7 @@ func (encoder *Encoder) encodePlaintext(p *Plaintext) {
 }
 
 // DecodeUint decodes a batched plaintext and returns the coefficients in a uint64 slice.
-func (encoder *Encoder) DecodeUint(plaintext *Plaintext) (coeffs []uint64) {
+func (encoder *encoder) DecodeUint(plaintext *Plaintext) (coeffs []uint64) {
 
 	encoder.simplescaler.Scale(plaintext.value, encoder.polypool)
 
@@ -148,7 +155,7 @@ func (encoder *Encoder) DecodeUint(plaintext *Plaintext) (coeffs []uint64) {
 
 // DecodeInt decodes a batched plaintext and returns the coefficients in an int64 slice. It also decodes the sign (by centering the values around the plaintext
 // modulus).
-func (encoder *Encoder) DecodeInt(plaintext *Plaintext) (coeffs []int64) {
+func (encoder *encoder) DecodeInt(plaintext *Plaintext) (coeffs []int64) {
 
 	var value int64
 

--- a/bfv/encryptor.go
+++ b/bfv/encryptor.go
@@ -4,93 +4,87 @@ import (
 	"github.com/ldsec/lattigo/ring"
 )
 
-// Encryptor is a structure that holds the parameters needed to encrypt plaintexts.
-type Encryptor struct {
+// Encryptor is an interface for encryptors
+//
+// encrypt with pk: ciphertext = [pk[0]*u + m + e_0, pk[1]*u + e_1]
+// encrypt with sk: ciphertext = [-a*sk + m + e, a]
+type Encryptor interface {
+	// EncryptNew encrypts the input plaintext using the stored key and returns
+	// the result on a newly created ciphertext.
+	EncryptNew(plaintext *Plaintext) *Ciphertext
+
+	// Encrypt encrypts the input plaintext using the stored key, and returns
+	// the result on the receiver ciphertext.
+	Encrypt(plaintext *Plaintext, ciphertext *Ciphertext)
+}
+
+// encryptor is a structure that holds the parameters needed to encrypt plaintexts.
+type encryptor struct {
 	params     *Parameters
 	bfvContext *bfvContext
-	pk         *PublicKey
-	sk         *SecretKey
 	polypool   [3]*ring.Poly
 
 	baseconverter *ring.FastBasisExtender
 }
 
+type pkEncryptor struct {
+	encryptor
+	pk *PublicKey
+}
+
+type skEncryptor struct {
+	encryptor
+	sk *SecretKey
+}
+
 // NewEncryptorFromPk creates a new Encryptor with the provided public-key.
 // This encryptor can be used to encrypt plaintexts, using the stored key.
-func NewEncryptorFromPk(params *Parameters, pk *PublicKey) *Encryptor {
-	return newEncryptor(params, pk, nil)
+func NewEncryptorFromPk(params *Parameters, pk *PublicKey) Encryptor {
+	enc := newEncryptor(params)
+
+	if uint64(pk.pk[0].GetDegree()) != uint64(1<<params.LogN) || uint64(pk.pk[1].GetDegree()) != uint64(1<<params.LogN) {
+		panic("error: pk ring degree doesn't match bfvcontext ring degree")
+	}
+
+	return &pkEncryptor{enc, pk}
 }
 
 // NewEncryptorFromSk creates a new Encryptor with the provided secret-key.
 // This encryptor can be used to encrypt plaintexts, using the stored key.
-func NewEncryptorFromSk(params *Parameters, sk *SecretKey) *Encryptor {
-	return newEncryptor(params, nil, sk)
+func NewEncryptorFromSk(params *Parameters, sk *SecretKey) Encryptor {
+	enc := newEncryptor(params)
+
+	if uint64(sk.sk.GetDegree()) != uint64(1<<params.LogN) {
+		panic("error: sk ring degree doesn't match bfvcontext ring degree")
+	}
+
+	return &skEncryptor{enc, sk}
 }
 
-func newEncryptor(params *Parameters, pk *PublicKey, sk *SecretKey) (encryptor *Encryptor) {
-
+func newEncryptor(params *Parameters) encryptor {
 	if !params.isValid {
 		panic("cannot NewEncryptor: params not valid (check if they were generated properly)")
 	}
 
-	if pk != nil && (uint64(pk.pk[0].GetDegree()) != uint64(1<<params.LogN) || uint64(pk.pk[1].GetDegree()) != uint64(1<<params.LogN)) {
-		panic("error: pk ring degree doesn't match bfvcontext ring degree")
+	ctx := newBFVContext(params)
+	qp := ctx.contextQP
+
+	return encryptor{
+		params:        params.Copy(),
+		bfvContext:    ctx,
+		polypool:      [3]*ring.Poly{qp.NewPoly(), qp.NewPoly(), qp.NewPoly()},
+		baseconverter: ring.NewFastBasisExtender(ctx.contextQ, ctx.contextP),
 	}
-
-	if sk != nil && uint64(sk.sk.GetDegree()) != uint64(1<<params.LogN) {
-		panic("error: sk ring degree doesn't match bfvcontext ring degree")
-	}
-
-	encryptor = new(Encryptor)
-	encryptor.params = params.Copy()
-	encryptor.bfvContext = newBFVContext(params)
-	encryptor.pk = pk
-	encryptor.sk = sk
-
-	encryptor.polypool[0] = encryptor.bfvContext.contextQP.NewPoly()
-	encryptor.polypool[1] = encryptor.bfvContext.contextQP.NewPoly()
-	encryptor.polypool[2] = encryptor.bfvContext.contextQP.NewPoly()
-
-	encryptor.baseconverter = ring.NewFastBasisExtender(encryptor.bfvContext.contextQ, encryptor.bfvContext.contextP)
-
-	return
 }
 
-// EncryptNew encrypts the input plaintext using the stored key and returns
-// the result on a newly created ciphertext.
-//
-// encrypt with pk: ciphertext = [pk[0]*u + m + e_0, pk[1]*u + e_1]
-// encrypt with sk: ciphertext = [-a*sk + m + e, a]
-func (encryptor *Encryptor) EncryptNew(plaintext *Plaintext) (ciphertext *Ciphertext) {
-
-	ciphertext = NewCiphertext(encryptor.params, 1)
+func (encryptor *pkEncryptor) EncryptNew(plaintext *Plaintext) *Ciphertext {
+	ciphertext := NewCiphertext(encryptor.params, 1)
 	encryptor.Encrypt(plaintext, ciphertext)
-	return
+
+	return ciphertext
 }
 
-// Encrypt encrypts the input plaintext using the stored key, and returns the result
-// on the receiver ciphertext.
-//
-// encrypt with pk: ciphertext = [pk[0]*u + m + e_0, pk[1]*u + e_1]
-// encrypt with sk: ciphertext = [-a*sk + m + e, a]
-func (encryptor *Encryptor) Encrypt(plaintext *Plaintext, ciphertext *Ciphertext) {
-
-	if encryptor.sk != nil {
-
-		encryptfromsk(encryptor, plaintext, ciphertext)
-
-	} else if encryptor.pk != nil {
-
-		encryptfrompk(encryptor, plaintext, ciphertext)
-
-	} else {
-
-		panic("cannot encrypt -> public-key and/or secret-key has not been set")
-	}
-}
-
-func encryptfrompk(encryptor *Encryptor, plaintext *Plaintext, ciphertext *Ciphertext) {
-
+func (encryptor *pkEncryptor) Encrypt(plaintext *Plaintext, ciphertext *Ciphertext) {
 	ringContext := encryptor.bfvContext.contextQP
 
 	// u
@@ -121,11 +115,16 @@ func encryptfrompk(encryptor *Encryptor, plaintext *Plaintext, ciphertext *Ciphe
 	// ct[0] = pk[0]*u + e0 + m
 	// ct[1] = pk[1]*u + e1
 	ringContext.Add(ciphertext.value[0], plaintext.value, ciphertext.value[0])
-
 }
 
-func encryptfromsk(encryptor *Encryptor, plaintext *Plaintext, ciphertext *Ciphertext) {
+func (encryptor *skEncryptor) EncryptNew(plaintext *Plaintext) *Ciphertext {
+	ciphertext := NewCiphertext(encryptor.params, 1)
+	encryptor.Encrypt(plaintext, ciphertext)
 
+	return ciphertext
+}
+
+func (encryptor *skEncryptor) Encrypt(plaintext *Plaintext, ciphertext *Ciphertext) {
 	ringContext := encryptor.bfvContext.contextQP
 
 	// ct = [(-a*s + e)/P , a/P]
@@ -145,5 +144,4 @@ func encryptfromsk(encryptor *Encryptor, plaintext *Plaintext, ciphertext *Ciphe
 
 	// ct = [-a*s + m + e , a]
 	ringContext.Add(ciphertext.value[0], plaintext.value, ciphertext.value[0])
-
 }

--- a/ckks/algorithms.go
+++ b/ckks/algorithms.go
@@ -6,7 +6,7 @@ import (
 
 // PowerOf2 compute ct0^(2^logPow2), consuming logPow2 levels, and returns the result on ct1. Providing an evaluation
 // key is necessary when logPow2 > 1.
-func (evaluator *Evaluator) PowerOf2(el0 *Ciphertext, logPow2 uint64, evakey *EvaluationKey, elOut *Ciphertext) {
+func (evaluator *evaluator) PowerOf2(el0 *Ciphertext, logPow2 uint64, evakey *EvaluationKey, elOut *Ciphertext) {
 
 	if logPow2 == 0 {
 
@@ -32,7 +32,7 @@ func (evaluator *Evaluator) PowerOf2(el0 *Ciphertext, logPow2 uint64, evakey *Ev
 
 // PowerNew compute ct0^degree, consuming log(degree) levels, and returns the result on a new element. Providing an evaluation
 // key is necessary when degree > 2.
-func (evaluator *Evaluator) PowerNew(op *Ciphertext, degree uint64, evakey *EvaluationKey) (opOut *Ciphertext) {
+func (evaluator *evaluator) PowerNew(op *Ciphertext, degree uint64, evakey *EvaluationKey) (opOut *Ciphertext) {
 	opOut = NewCiphertext(evaluator.params, 1, op.Level(), op.Scale())
 	evaluator.Power(op, degree, evakey, opOut)
 	return
@@ -40,7 +40,7 @@ func (evaluator *Evaluator) PowerNew(op *Ciphertext, degree uint64, evakey *Eval
 
 // Power compute ct0^degree, consuming log(degree) levels, and returns the result on res. Providing an evaluation
 // key is necessary when degree > 2.
-func (evaluator *Evaluator) Power(ct0 *Ciphertext, degree uint64, evakey *EvaluationKey, res *Ciphertext) {
+func (evaluator *evaluator) Power(ct0 *Ciphertext, degree uint64, evakey *EvaluationKey, res *Ciphertext) {
 
 	tmpct0 := ct0.CopyNew()
 
@@ -72,7 +72,7 @@ func (evaluator *Evaluator) Power(ct0 *Ciphertext, degree uint64, evakey *Evalua
 
 // InverseNew computes 1/ct0 and returns the result on a new element, iterating for n steps and consuming n levels. The algorithm requires the encrypted values to be in the range
 // [-1.5 - 1.5i, 1.5 + 1.5i]  or the result will be  wrong. Each iteration increases the precision.
-func (evaluator *Evaluator) InverseNew(ct0 *Ciphertext, steps uint64, evakey *EvaluationKey) (res *Ciphertext) {
+func (evaluator *evaluator) InverseNew(ct0 *Ciphertext, steps uint64, evakey *EvaluationKey) (res *Ciphertext) {
 
 	cbar := evaluator.NegNew(ct0)
 

--- a/ckks/chebyshev_evaluation.go
+++ b/ckks/chebyshev_evaluation.go
@@ -7,7 +7,7 @@ import (
 
 // EvaluateChebyFast evaluates the input Chebyshev polynomial with the input ciphertext.
 // Faster than EvaluateChebyEco but consumes ceil(log(deg)) + 2 levels.
-func (evaluator *Evaluator) EvaluateChebyFast(ct *Ciphertext, cheby *ChebyshevInterpolation, evakey *EvaluationKey) (res *Ciphertext) {
+func (evaluator *evaluator) EvaluateChebyFast(ct *Ciphertext, cheby *ChebyshevInterpolation, evakey *EvaluationKey) (res *Ciphertext) {
 
 	C := make(map[uint64]*Ciphertext)
 
@@ -33,7 +33,7 @@ func (evaluator *Evaluator) EvaluateChebyFast(ct *Ciphertext, cheby *ChebyshevIn
 
 // EvaluateChebyEco evaluates the input Chebyshev polynomial with the input ciphertext.
 // Slower than EvaluateChebyFast but consumes ceil(log(deg)) + 1 levels.
-func (evaluator *Evaluator) EvaluateChebyEco(ct *Ciphertext, cheby *ChebyshevInterpolation, evakey *EvaluationKey) (res *Ciphertext) {
+func (evaluator *evaluator) EvaluateChebyEco(ct *Ciphertext, cheby *ChebyshevInterpolation, evakey *EvaluationKey) (res *Ciphertext) {
 
 	C := make(map[uint64]*Ciphertext)
 
@@ -57,7 +57,7 @@ func (evaluator *Evaluator) EvaluateChebyEco(ct *Ciphertext, cheby *ChebyshevInt
 	return recurseCheby(cheby.degree, L, M, cheby.coeffs, C, evaluator, evakey)
 }
 
-func computePowerBasisCheby(n uint64, C map[uint64]*Ciphertext, evaluator *Evaluator, evakey *EvaluationKey) {
+func computePowerBasisCheby(n uint64, C map[uint64]*Ciphertext, evaluator *evaluator, evakey *EvaluationKey) {
 
 	// Given a hash table with the first three evaluations of the Chebyshev ring at x in the interval a, b:
 	// C0 = 1 (actually not stored in the hash table)
@@ -100,7 +100,7 @@ func computePowerBasisCheby(n uint64, C map[uint64]*Ciphertext, evaluator *Evalu
 	}
 }
 
-func recurseCheby(maxDegree, L, M uint64, coeffs map[uint64]complex128, C map[uint64]*Ciphertext, evaluator *Evaluator, evakey *EvaluationKey) (res *Ciphertext) {
+func recurseCheby(maxDegree, L, M uint64, coeffs map[uint64]complex128, C map[uint64]*Ciphertext, evaluator *evaluator, evakey *EvaluationKey) (res *Ciphertext) {
 
 	// Recursively computes the evalution of the Chebyshev polynomial using a baby-set giant-step algorithm.
 

--- a/ckks/ckks_benchmarks_test.go
+++ b/ckks/ckks_benchmarks_test.go
@@ -27,7 +27,7 @@ func benchEncoder(b *testing.B) {
 
 			values := make([]complex128, slots)
 			for i := uint64(0); i < slots; i++ {
-				values[i] = complex(randomFloat(0.1, 1), 0)
+				values[i] = complex(randomFloat(-1, 1), randomFloat(-1, 1))
 			}
 
 			plaintext := NewPlaintext(parameters, parameters.MaxLevel(), parameters.Scale)
@@ -41,7 +41,7 @@ func benchEncoder(b *testing.B) {
 
 			values := make([]complex128, slots)
 			for i := uint64(0); i < slots; i++ {
-				values[i] = complex(randomFloat(0.1, 1), 0)
+				values[i] = complex(randomFloat(-1, 1), randomFloat(-1, 1))
 			}
 
 			plaintext := NewPlaintext(parameters, parameters.MaxLevel(), parameters.Scale)

--- a/ckks/ckks_benchmarks_test.go
+++ b/ckks/ckks_benchmarks_test.go
@@ -201,7 +201,7 @@ func benchHoistedRotations(b *testing.B) {
 	for _, parameters := range testParams.ckksParameters {
 
 		params := genCkksParams(parameters)
-		evaluator := params.evaluator
+		evaluator := params.evaluator.(*evaluator)
 
 		rotkey := NewRotationKeys()
 		params.kgen.GenRot(RotationLeft, params.sk, 5, rotkey)

--- a/ckks/ckks_test.go
+++ b/ckks/ckks_test.go
@@ -39,7 +39,7 @@ type ckksParams struct {
 	pk          *PublicKey
 	encryptorPk Encryptor
 	encryptorSk Encryptor
-	decryptor   *Decryptor
+	decryptor   Decryptor
 	evaluator   *Evaluator
 }
 
@@ -152,7 +152,7 @@ func newTestVectorsReals(contextParams *ckksParams, encryptor Encryptor, a, b fl
 	return values, plaintext, ciphertext
 }
 
-func verifyTestVectors(contextParams *ckksParams, decryptor *Decryptor, valuesWant []complex128, element interface{}, t *testing.T) {
+func verifyTestVectors(contextParams *ckksParams, decryptor Decryptor, valuesWant []complex128, element interface{}, t *testing.T) {
 
 	var plaintextTest *Plaintext
 	var valuesTest []complex128

--- a/ckks/ckks_test.go
+++ b/ckks/ckks_test.go
@@ -33,7 +33,7 @@ func testString(opname string, params *Parameters) string {
 type ckksParams struct {
 	params      *Parameters
 	ckkscontext *Context
-	encoder     *Encoder
+	encoder     Encoder
 	kgen        *KeyGenerator
 	sk          *SecretKey
 	pk          *PublicKey

--- a/ckks/ckks_test.go
+++ b/ckks/ckks_test.go
@@ -2,7 +2,6 @@ package ckks
 
 import (
 	"fmt"
-	"github.com/ldsec/lattigo/utils"
 	"log"
 	"math"
 	"math/cmplx"
@@ -10,6 +9,8 @@ import (
 	"sort"
 	"testing"
 	"time"
+
+	"github.com/ldsec/lattigo/utils"
 )
 
 func check(t *testing.T, err error) {
@@ -36,8 +37,8 @@ type ckksParams struct {
 	kgen        *KeyGenerator
 	sk          *SecretKey
 	pk          *PublicKey
-	encryptorPk *Encryptor
-	encryptorSk *Encryptor
+	encryptorPk Encryptor
+	encryptorSk Encryptor
 	decryptor   *Decryptor
 	evaluator   *Evaluator
 }
@@ -105,7 +106,7 @@ func genCkksParams(contextParameters *Parameters) (params *ckksParams) {
 
 }
 
-func newTestVectors(contextParams *ckksParams, encryptor *Encryptor, a float64, t *testing.T) (values []complex128, plaintext *Plaintext, ciphertext *Ciphertext) {
+func newTestVectors(contextParams *ckksParams, encryptor Encryptor, a float64, t *testing.T) (values []complex128, plaintext *Plaintext, ciphertext *Ciphertext) {
 
 	slots := uint64(1 << contextParams.params.LogSlots)
 
@@ -128,7 +129,7 @@ func newTestVectors(contextParams *ckksParams, encryptor *Encryptor, a float64, 
 	return values, plaintext, ciphertext
 }
 
-func newTestVectorsReals(contextParams *ckksParams, encryptor *Encryptor, a, b float64, t *testing.T) (values []complex128, plaintext *Plaintext, ciphertext *Ciphertext) {
+func newTestVectorsReals(contextParams *ckksParams, encryptor Encryptor, a, b float64, t *testing.T) (values []complex128, plaintext *Plaintext, ciphertext *Ciphertext) {
 
 	slots := uint64(1 << contextParams.params.LogSlots)
 

--- a/ckks/ckks_test.go
+++ b/ckks/ckks_test.go
@@ -34,7 +34,7 @@ type ckksParams struct {
 	params      *Parameters
 	ckkscontext *Context
 	encoder     Encoder
-	kgen        *KeyGenerator
+	kgen        KeyGenerator
 	sk          *SecretKey
 	pk          *PublicKey
 	encryptorPk Encryptor

--- a/ckks/ckks_test.go
+++ b/ckks/ckks_test.go
@@ -40,7 +40,7 @@ type ckksParams struct {
 	encryptorPk Encryptor
 	encryptorSk Encryptor
 	decryptor   Decryptor
-	evaluator   *Evaluator
+	evaluator   Evaluator
 }
 
 type ckksTestParameters struct {

--- a/ckks/encoder.go
+++ b/ckks/encoder.go
@@ -13,7 +13,6 @@ type Encoder interface {
 	Decode(plaintext *Plaintext, slots uint64) (res []complex128)
 }
 
-
 type encoder struct {
 	params       *Parameters
 	ckksContext  *Context

--- a/ckks/encryptor.go
+++ b/ckks/encryptor.go
@@ -4,103 +4,87 @@ import (
 	"github.com/ldsec/lattigo/ring"
 )
 
-// Encryptor is a struct used to encrypt plaintext and storing the public-key and/or secret-key.
-type Encryptor struct {
+// Encryptor in an interface for encryptors
+//
+// encrypt with pk : ciphertext = [pk[0]*u + m + e_0, pk[1]*u + e_1]
+// encrypt with sk : ciphertext = [-a*sk + m + e, a]
+type Encryptor interface {
+	// EncryptNew encrypts the input plaintext using the stored key and returns
+	// the result on a newly created ciphertext.
+	EncryptNew(plaintext *Plaintext) *Ciphertext
+
+	// Encrypt encrypts the input plaintext using the stored key, and returns
+	// the result on the reciver ciphertext.
+	Encrypt(plaintext *Plaintext, ciphertext *Ciphertext)
+}
+
+// encryptor is a structure holding the parameters needed to encrypt plaintexts.
+type encryptor struct {
 	params      *Parameters
 	ckksContext *Context
-	pk          *PublicKey
-	sk          *SecretKey
 	polypool    [3]*ring.Poly
-
-	rescalepool []uint64
 
 	baseconverter *ring.FastBasisExtender
 }
 
+type pkEncryptor struct {
+	encryptor
+	pk *PublicKey
+}
+
+type skEncryptor struct {
+	encryptor
+	sk *SecretKey
+}
+
 // NewEncryptorFromPk creates a new Encryptor with the provided public-key.
 // This encryptor can be used to encrypt plaintexts, using the stored key.
-func NewEncryptorFromPk(params *Parameters, pk *PublicKey) *Encryptor {
-	return newEncryptor(params, pk, nil)
+func NewEncryptorFromPk(params *Parameters, pk *PublicKey) Encryptor {
+	enc := newEncryptor(params)
+
+	if uint64(pk.pk[0].GetDegree()) != uint64(1<<params.LogN) || uint64(pk.pk[1].GetDegree()) != uint64(1<<params.LogN) {
+		panic("pk ring degree doesn't match ckkscontext ring degree")
+	}
+
+	return &pkEncryptor{enc, pk}
 }
 
 // NewEncryptorFromSk creates a new Encryptor with the provided secret-key.
 // This encryptor can be used to encrypt plaintexts, using the stored key.
-func NewEncryptorFromSk(params *Parameters, sk *SecretKey) *Encryptor {
-	return newEncryptor(params, nil, sk)
+func NewEncryptorFromSk(params *Parameters, sk *SecretKey) Encryptor {
+	enc := newEncryptor(params)
+
+	if uint64(sk.sk.GetDegree()) != uint64(1<<params.LogN) {
+		panic("sk ring degree doesn't match ckkscontext ring degree")
+	}
+
+	return &skEncryptor{enc, sk}
 }
 
-// NewEncryptor creates a new Encryptor with the input public-key and/or secret-key.
-// This encryptor can be used to encrypt plaintexts, using the stored keys.
-func newEncryptor(params *Parameters, pk *PublicKey, sk *SecretKey) (encryptor *Encryptor) {
-
+func newEncryptor(params *Parameters) encryptor {
 	if !params.isValid {
 		panic("cannot create new Encryptor, parameters are invalid (check if the generation was done properly)")
 	}
 
-	if pk != nil && (uint64(pk.pk[0].GetDegree()) != uint64(1<<params.LogN) || uint64(pk.pk[1].GetDegree()) != uint64(1<<params.LogN)) {
-		panic("pk ring degree doesn't match ckkscontext ring degree")
+	ctx := newContext(params)
+	qp := ctx.contextQP
+
+	return encryptor{
+		params:        params.Copy(),
+		ckksContext:   ctx,
+		polypool:      [3]*ring.Poly{qp.NewPoly(), qp.NewPoly(), qp.NewPoly()},
+		baseconverter: ring.NewFastBasisExtender(ctx.contextQ, ctx.contextP),
 	}
-
-	if sk != nil && uint64(sk.sk.GetDegree()) != uint64(1<<params.LogN) {
-		panic("sk ring degree doesn't match ckkscontext ring degree")
-	}
-
-	encryptor = new(Encryptor)
-	encryptor.params = params.Copy()
-	encryptor.ckksContext = newContext(params)
-	encryptor.pk = pk
-	encryptor.sk = sk
-
-	encryptor.polypool[0] = encryptor.ckksContext.contextQP.NewPoly()
-	encryptor.polypool[1] = encryptor.ckksContext.contextQP.NewPoly()
-	encryptor.polypool[2] = encryptor.ckksContext.contextQP.NewPoly()
-
-	encryptor.rescalepool = make([]uint64, encryptor.ckksContext.n)
-
-	encryptor.baseconverter = ring.NewFastBasisExtender(encryptor.ckksContext.contextQ, encryptor.ckksContext.contextP)
-
-	return encryptor
 }
 
-// EncryptNew encrypts the input plaintext using the stored key and returns
-// the result on a newly created ciphertext.
-//
-// encrypt with pk : ciphertext = [pk[0]*u + m + e_0, pk[1]*u + e_1]
-// encrypt with sk : ciphertext = [-a*sk + m + e, a]
-func (encryptor *Encryptor) EncryptNew(plaintext *Plaintext) (ciphertext *Ciphertext) {
-
-	ciphertext = NewCiphertext(encryptor.params, 1, plaintext.Level(), plaintext.Scale())
+func (encryptor *pkEncryptor) EncryptNew(plaintext *Plaintext) *Ciphertext {
+	ciphertext := NewCiphertext(encryptor.params, 1, plaintext.Level(), plaintext.Scale())
 	encryptor.Encrypt(plaintext, ciphertext)
-	return
+
+	return ciphertext
 }
 
-// Encrypt encrypts the input plaintext using the stored key, and returns the result
-// on the reciver ciphertext.
-//
-// encrypt with pk : ciphertext = [pk[0]*u + m + e_0, pk[1]*u + e_1]
-// encrypt with sk : ciphertext = [-a*sk + m + e, a]
-func (encryptor *Encryptor) Encrypt(plaintext *Plaintext, ciphertext *Ciphertext) {
-
-	if plaintext.Level() != encryptor.ckksContext.levels-1 {
-		panic("cannot encrypt -> plaintext not at maximum level")
-	}
-
-	if encryptor.sk != nil {
-
-		encryptfromsk(encryptor, plaintext, ciphertext)
-
-	} else if encryptor.pk != nil {
-
-		encryptfrompk(encryptor, plaintext, ciphertext)
-
-	} else {
-
-		panic("cannot encrypt -> public-key and/or secret-key has not been set")
-	}
-}
-
-func encryptfrompk(encryptor *Encryptor, plaintext *Plaintext, ciphertext *Ciphertext) {
-
+func (encryptor *pkEncryptor) Encrypt(plaintext *Plaintext, ciphertext *Ciphertext) {
 	// We sample a R-WLE instance (encryption of zero) over the keys context (ciphertext context + special prime)
 
 	contextQP := encryptor.ckksContext.contextQP
@@ -138,7 +122,14 @@ func encryptfrompk(encryptor *Encryptor, plaintext *Plaintext, ciphertext *Ciphe
 	ciphertext.isNTT = true
 }
 
-func encryptfromsk(encryptor *Encryptor, plaintext *Plaintext, ciphertext *Ciphertext) {
+func (encryptor *skEncryptor) EncryptNew(plaintext *Plaintext) *Ciphertext {
+	ciphertext := NewCiphertext(encryptor.params, 1, plaintext.Level(), plaintext.Scale())
+	encryptor.Encrypt(plaintext, ciphertext)
+
+	return ciphertext
+}
+
+func (encryptor *skEncryptor) Encrypt(plaintext *Plaintext, ciphertext *Ciphertext) {
 	contextQP := encryptor.ckksContext.contextQP
 	contextQ := encryptor.ckksContext.contextQ
 

--- a/ckks/polynomial_evaluation.go
+++ b/ckks/polynomial_evaluation.go
@@ -7,7 +7,7 @@ import (
 
 // EvaluatePolyFast evaluates the polynomial a + bx + cx^2... with the input ciphertext.
 // Faster than EvaluatePolyEco but consumes ceil(log2(deg)) + 1 levels.
-func (evaluator *Evaluator) EvaluatePolyFast(ct *Ciphertext, coeffs interface{}, evakey *EvaluationKey) (res *Ciphertext) {
+func (evaluator *evaluator) EvaluatePolyFast(ct *Ciphertext, coeffs interface{}, evakey *EvaluationKey) (res *Ciphertext) {
 
 	degree, coeffsMap := convertCoeffs(coeffs)
 
@@ -31,7 +31,7 @@ func (evaluator *Evaluator) EvaluatePolyFast(ct *Ciphertext, coeffs interface{},
 
 // EvaluatePolyEco evaluates the polynomial a + bx + cx^2... with the input ciphertext.
 // Slower than EvaluatePolyFast but consumes ceil(log2(deg)) levels.
-func (evaluator *Evaluator) EvaluatePolyEco(ct *Ciphertext, coeffs interface{}, evakey *EvaluationKey) (res *Ciphertext) {
+func (evaluator *evaluator) EvaluatePolyEco(ct *Ciphertext, coeffs interface{}, evakey *EvaluationKey) (res *Ciphertext) {
 
 	degree, coeffsMap := convertCoeffs(coeffs)
 
@@ -73,7 +73,7 @@ func convertCoeffs(coeffs interface{}) (degree uint64, coeffsMap map[uint64]comp
 	return uint64(len(coeffsMap)) - 1, coeffsMap
 }
 
-func computePowerBasis(n uint64, C map[uint64]*Ciphertext, evaluator *Evaluator, evakey *EvaluationKey) {
+func computePowerBasis(n uint64, C map[uint64]*Ciphertext, evaluator *evaluator, evakey *EvaluationKey) {
 
 	if C[n] == nil {
 
@@ -112,7 +112,7 @@ func splitCoeffs(coeffs map[uint64]complex128, degree, maxDegree uint64) (coeffs
 	return coeffsq, coeffsr
 }
 
-func recurse(maxDegree, L, M uint64, coeffs map[uint64]complex128, C map[uint64]*Ciphertext, evaluator *Evaluator, evakey *EvaluationKey) (res *Ciphertext) {
+func recurse(maxDegree, L, M uint64, coeffs map[uint64]complex128, C map[uint64]*Ciphertext, evaluator *evaluator, evakey *EvaluationKey) (res *Ciphertext) {
 
 	if maxDegree <= (1 << L) {
 		return evaluatePolyFromPowerBasis(coeffs, C, evaluator, evakey)
@@ -139,7 +139,7 @@ func recurse(maxDegree, L, M uint64, coeffs map[uint64]complex128, C map[uint64]
 
 }
 
-func evaluatePolyFromPowerBasis(coeffs map[uint64]complex128, C map[uint64]*Ciphertext, evaluator *Evaluator, evakey *EvaluationKey) (res *Ciphertext) {
+func evaluatePolyFromPowerBasis(coeffs map[uint64]complex128, C map[uint64]*Ciphertext, evaluator *evaluator, evakey *EvaluationKey) (res *Ciphertext) {
 
 	res = NewCiphertext(evaluator.params, 1, C[1].Level(), C[1].Scale())
 

--- a/dbfv/dbfv_test.go
+++ b/dbfv/dbfv_test.go
@@ -2,12 +2,13 @@ package dbfv
 
 import (
 	"fmt"
-	"github.com/ldsec/lattigo/bfv"
-	"github.com/ldsec/lattigo/ring"
-	"github.com/ldsec/lattigo/utils"
 	"log"
 	"math/big"
 	"testing"
+
+	"github.com/ldsec/lattigo/bfv"
+	"github.com/ldsec/lattigo/ring"
+	"github.com/ldsec/lattigo/utils"
 )
 
 func check(t *testing.T, err error) {
@@ -37,7 +38,7 @@ type dbfvTestContext struct {
 	pk0 *bfv.PublicKey
 	pk1 *bfv.PublicKey
 
-	encryptorPk0 *bfv.Encryptor
+	encryptorPk0 bfv.Encryptor
 	decryptorSk0 *bfv.Decryptor
 	decryptorSk1 *bfv.Decryptor
 	evaluator    *bfv.Evaluator
@@ -678,7 +679,7 @@ func testRefresh(t *testing.T) {
 	}
 }
 
-func newTestVectors(contextParams *dbfvTestContext, encryptor *bfv.Encryptor, t *testing.T) (coeffs []uint64, plaintext *bfv.Plaintext, ciphertext *bfv.Ciphertext) {
+func newTestVectors(contextParams *dbfvTestContext, encryptor bfv.Encryptor, t *testing.T) (coeffs []uint64, plaintext *bfv.Plaintext, ciphertext *bfv.Ciphertext) {
 	coeffsPol := contextParams.contextT.NewUniformPoly()
 	plaintext = bfv.NewPlaintext(contextParams.params)
 	contextParams.encoder.EncodeUint(coeffsPol.Coeffs[0], plaintext)

--- a/dbfv/dbfv_test.go
+++ b/dbfv/dbfv_test.go
@@ -26,7 +26,7 @@ type dbfvTestContext struct {
 
 	params *bfv.Parameters
 
-	encoder *bfv.Encoder
+	encoder bfv.Encoder
 	kgen    *bfv.KeyGenerator
 
 	sk0Shards []*bfv.SecretKey

--- a/dbfv/dbfv_test.go
+++ b/dbfv/dbfv_test.go
@@ -39,8 +39,8 @@ type dbfvTestContext struct {
 	pk1 *bfv.PublicKey
 
 	encryptorPk0 bfv.Encryptor
-	decryptorSk0 *bfv.Decryptor
-	decryptorSk1 *bfv.Decryptor
+	decryptorSk0 bfv.Decryptor
+	decryptorSk1 bfv.Decryptor
 	evaluator    *bfv.Evaluator
 }
 
@@ -687,7 +687,7 @@ func newTestVectors(contextParams *dbfvTestContext, encryptor bfv.Encryptor, t *
 	return coeffsPol.Coeffs[0], plaintext, ciphertext
 }
 
-func verifyTestVectors(contextParams *dbfvTestContext, decryptor *bfv.Decryptor, coeffs []uint64, ciphertext *bfv.Ciphertext, t *testing.T) {
+func verifyTestVectors(contextParams *dbfvTestContext, decryptor bfv.Decryptor, coeffs []uint64, ciphertext *bfv.Ciphertext, t *testing.T) {
 	if utils.EqualSliceUint64(coeffs, contextParams.encoder.DecodeUint(decryptor.DecryptNew(ciphertext))) != true {
 		t.Errorf("decryption error")
 	}

--- a/dbfv/dbfv_test.go
+++ b/dbfv/dbfv_test.go
@@ -41,7 +41,7 @@ type dbfvTestContext struct {
 	encryptorPk0 bfv.Encryptor
 	decryptorSk0 bfv.Decryptor
 	decryptorSk1 bfv.Decryptor
-	evaluator    *bfv.Evaluator
+	evaluator    bfv.Evaluator
 }
 
 type dbfvTestParameters struct {

--- a/dckks/dckks_test.go
+++ b/dckks/dckks_test.go
@@ -34,8 +34,8 @@ type dckksTestContext struct {
 	evaluator    *ckks.Evaluator
 
 	encryptorPk0 ckks.Encryptor
-	decryptorSk0 *ckks.Decryptor
-	decryptorSk1 *ckks.Decryptor
+	decryptorSk0 ckks.Decryptor
+	decryptorSk1 ckks.Decryptor
 
 	pk0 *ckks.PublicKey
 	pk1 *ckks.PublicKey
@@ -682,7 +682,7 @@ func newTestVectors(contextParams *dckksTestContext, encryptor ckks.Encryptor, a
 	return values, plaintext, ciphertext
 }
 
-func verifyTestVectors(contextParams *dckksTestContext, decryptor *ckks.Decryptor, valuesWant []complex128, element interface{}, t *testing.T) {
+func verifyTestVectors(contextParams *dckksTestContext, decryptor ckks.Decryptor, valuesWant []complex128, element interface{}, t *testing.T) {
 
 	var plaintextTest *ckks.Plaintext
 	var valuesTest []complex128

--- a/dckks/dckks_test.go
+++ b/dckks/dckks_test.go
@@ -31,7 +31,7 @@ type dckksTestContext struct {
 	params       *ckks.Parameters
 	dckksContext *dckksContext
 	encoder      ckks.Encoder
-	evaluator    *ckks.Evaluator
+	evaluator    ckks.Evaluator
 
 	encryptorPk0 ckks.Encryptor
 	decryptorSk0 ckks.Decryptor

--- a/dckks/dckks_test.go
+++ b/dckks/dckks_test.go
@@ -30,7 +30,7 @@ func testString(opname string, parties uint64, params *ckks.Parameters) string {
 type dckksTestContext struct {
 	params       *ckks.Parameters
 	dckksContext *dckksContext
-	encoder      *ckks.Encoder
+	encoder      ckks.Encoder
 	evaluator    *ckks.Evaluator
 
 	encryptorPk0 ckks.Encryptor

--- a/dckks/dckks_test.go
+++ b/dckks/dckks_test.go
@@ -2,11 +2,12 @@ package dckks
 
 import (
 	"fmt"
-	"github.com/ldsec/lattigo/ckks"
-	"github.com/ldsec/lattigo/ring"
 	"math"
 	"sort"
 	"testing"
+
+	"github.com/ldsec/lattigo/ckks"
+	"github.com/ldsec/lattigo/ring"
 )
 
 func check(t *testing.T, err error) {
@@ -32,7 +33,7 @@ type dckksTestContext struct {
 	encoder      *ckks.Encoder
 	evaluator    *ckks.Evaluator
 
-	encryptorPk0 *ckks.Encryptor
+	encryptorPk0 ckks.Encryptor
 	decryptorSk0 *ckks.Decryptor
 	decryptorSk1 *ckks.Decryptor
 
@@ -660,7 +661,7 @@ func testRefresh(t *testing.T) {
 	}
 }
 
-func newTestVectors(contextParams *dckksTestContext, encryptor *ckks.Encryptor, a float64, t *testing.T) (values []complex128, plaintext *ckks.Plaintext, ciphertext *ckks.Ciphertext) {
+func newTestVectors(contextParams *dckksTestContext, encryptor ckks.Encryptor, a float64, t *testing.T) (values []complex128, plaintext *ckks.Plaintext, ciphertext *ckks.Ciphertext) {
 
 	slots := uint64(1 << contextParams.params.LogSlots)
 

--- a/examples/bfv/examples_bfv.go
+++ b/examples/bfv/examples_bfv.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/ldsec/lattigo/bfv"
-	"github.com/ldsec/lattigo/ring"
 	"math"
 	"math/bits"
+
+	"github.com/ldsec/lattigo/bfv"
+	"github.com/ldsec/lattigo/ring"
 )
 
 func obliviousRiding() {

--- a/examples/ckks/examples_ckks.go
+++ b/examples/ckks/examples_ckks.go
@@ -47,7 +47,7 @@ func chebyshevinterpolation() {
 	encryptor = ckks.NewEncryptorFromPk(params, pk)
 
 	// Decryptor
-	var decryptor *ckks.Decryptor
+	var decryptor ckks.Decryptor
 	decryptor = ckks.NewDecryptor(params, sk)
 
 	// Evaluator

--- a/examples/ckks/examples_ckks.go
+++ b/examples/ckks/examples_ckks.go
@@ -34,25 +34,19 @@ func chebyshevinterpolation() {
 
 	// Keys
 	kgen := ckks.NewKeyGenerator(params)
-	var sk *ckks.SecretKey
-	var pk *ckks.PublicKey
-	sk, pk = kgen.NewKeyPair()
+	sk, pk := kgen.NewKeyPair()
 
 	// Relinearization key
-	var rlk *ckks.EvaluationKey
-	rlk = kgen.NewRelinKey(sk)
+	rlk := kgen.NewRelinKey(sk)
 
 	// Encryptor
-	var encryptor ckks.Encryptor
-	encryptor = ckks.NewEncryptorFromPk(params, pk)
+	encryptor := ckks.NewEncryptorFromPk(params, pk)
 
 	// Decryptor
-	var decryptor ckks.Decryptor
-	decryptor = ckks.NewDecryptor(params, sk)
+	decryptor := ckks.NewDecryptor(params, sk)
 
 	// Evaluator
-	var evaluator ckks.Evaluator
-	evaluator = ckks.NewEvaluator(params)
+	evaluator := ckks.NewEvaluator(params)
 
 	slots := uint64(1 << (params.LogN - 1))
 

--- a/examples/ckks/examples_ckks.go
+++ b/examples/ckks/examples_ckks.go
@@ -43,7 +43,7 @@ func chebyshevinterpolation() {
 	rlk = kgen.NewRelinKey(sk)
 
 	// Encryptor
-	var encryptor *ckks.Encryptor
+	var encryptor ckks.Encryptor
 	encryptor = ckks.NewEncryptorFromPk(params, pk)
 
 	// Decryptor

--- a/examples/ckks/examples_ckks.go
+++ b/examples/ckks/examples_ckks.go
@@ -51,7 +51,7 @@ func chebyshevinterpolation() {
 	decryptor = ckks.NewDecryptor(params, sk)
 
 	// Evaluator
-	var evaluator *ckks.Evaluator
+	var evaluator ckks.Evaluator
 	evaluator = ckks.NewEvaluator(params)
 
 	slots := uint64(1 << (params.LogN - 1))

--- a/ring/ring_basis_extension.go
+++ b/ring/ring_basis_extension.go
@@ -305,7 +305,7 @@ func (basisextender *FastBasisExtender) ModDownSplitedPQ(level uint64, p1Q, p1P,
 	// In total we do len(P) + len(Q) NTT, which is optimal (linear in the number of moduli of P and Q)
 }
 
-// ModDownSplited reduces the basis of a polynomial.
+// ModDownSplitedQP reduces the basis of a polynomial.
 // Given a polynomial with coefficients in basis {Q0,Q1....Qi} and {P0,P1...Pj}
 // Reduces its basis from {Q0,Q1....Qi} and {P0,P1...Pj} to {P0,P1...Pj}
 // and does a runded integer division of the result by Q.


### PR DESCRIPTION
This PR changes the `bfv.Encryptor` struct to an interface, adding a small hierarchy where `pk` and `sk` only exist in their respective implementation, and removing the "ugly" tests such as `if pk != nil {...} else if sk != nil {...}`.

This can also apply to `ckks.Encryptor`. For symmetry and abstraction, we can also change `Decryptor` to an interface (even though it only has one implementation), `Encoder`, etc.

What do you think?