### PR TITLE
Improve travis & Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ _testmain.go
 # vendor/
 
 .idea/
+
+# generated
+/Coding

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,10 @@
 language: go
 
 go:
+  - 1.x
+  - 1.14.x
   - 1.13.x
 
-env:
-  - GO111MODULE=on
-
 script:
-  - env GO111MODULE=on make test
-
-branches:
-  only:
-    - /.*/
-
-notifications:
-  email: false
+  - go build ./...
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.14.x
   - 1.13.x
 
+before_script: make test_fmt test_lint
 script:
   - go build ./...
-  - make test
+  - make test_local test_examples

--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,17 @@
-EXCLUDE_LINT = "_test.go"
+.DEFAULT_GOAL := local
 
-test_fmt:
-	@echo Checking correct formatting of files
-	@{ \
-		files=$$( go fmt ./... ); \
-		if [ -n "$$files" ]; then \
-		echo "Files not properly formatted: $$files"; \
-		exit 1; \
-		fi; \
-		if ! go vet ./...; then \
-		exit 1; \
-		fi \
-	}
+Coding/bin/Makefile.base:
+	git clone https://github.com/dedis/Coding
+include Coding/bin/Makefile.base
 
-test_lint:
-	@echo Checking linting of files
-	@{ \
-		go install golang.org/x/lint/golint; \
-		el=$(EXCLUDE_LINT); \
-		lintfiles=$$( golint ./... | egrep -v "$$el" ); \
-		if [ -n "$$lintfiles" ]; then \
-		echo "Lint errors:"; \
-		echo "$$lintfiles"; \
-		exit 1; \
-		fi \
-	}
-
-test_local:
-	go test -v -short -p=1 ./... -timeout=0
+.PHONY: test_examples
+test_examples:
 	go run ./examples/bfv/examples_bfv.go
 	go run ./examples/ckks/examples_ckks.go
 
-test: test_fmt test_local
+.PHONY: test_local
+test_local:
+	go test -v ./...
 
-local: test_fmt test_lint test_local
+.PHONY: local
+local: test_fmt test_lint test_local test_examples

--- a/bfv/params.go
+++ b/bfv/params.go
@@ -37,9 +37,13 @@ var tBatching = map[uint64][]uint64{
 }
 
 const (
+	// PN12QP109 is the index in DefaultParams for logQ1+P = 109
 	PN12QP109 = iota
+	// PN13QP218 is the index in DefaultParams for logQ1+P = 218
 	PN13QP218
+	// PN14QP438 is the index in DefaultParams for logQ1+P = 438
 	PN14QP438
+	// PN15QP880 is the index in DefaultParams for logQ1+P = 880
 	PN15QP880
 )
 

--- a/ckks/params.go
+++ b/ckks/params.go
@@ -25,10 +25,15 @@ func init() {
 }
 
 const (
+	// PN12QP109 is the index in DefaultParams for logQ1 = 109
 	PN12QP109 = iota
+	// PN13QP218 is the index in DefaultParams for logQ1 = 218
 	PN13QP218
+	// PN14QP438 is the index in DefaultParams for logQ1 = 438
 	PN14QP438
+	// PN15QP880 is the index in DefaultParams for logQ1 = 880
 	PN15QP880
+	// PN16QP1761 is the index in DefaultParams for logQ1 = 1761
 	PN16QP1761
 )
 

--- a/dbfv/dbfv.go
+++ b/dbfv/dbfv.go
@@ -69,6 +69,7 @@ func newDbfvContext(params *bfv.Parameters) *dbfvContext {
 	}
 }
 
+// NewCRPGenerator creates a CRPGenerator
 func NewCRPGenerator(params *bfv.Parameters, key []byte) *ring.CRPGenerator {
 	ctx := newDbfvContext(params)
 	return ring.NewCRPGenerator(key, ctx.contextQP)

--- a/dckks/dckks.go
+++ b/dckks/dckks.go
@@ -56,6 +56,7 @@ func newDckksContext(params *ckks.Parameters) (context *dckksContext) {
 	return
 }
 
+// NewCRPGenerator creates a CRPGenerator
 func NewCRPGenerator(params *ckks.Parameters, key []byte) *ring.CRPGenerator {
 	ctx := newDckksContext(params)
 	return ring.NewCRPGenerator(key, ctx.contextQP)

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,7 @@ module github.com/ldsec/lattigo
 
 go 1.13
 
-require golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
-
-require golang.org/x/lint v0.0.0-20190409202823-959b441ac422
-
-require github.com/stretchr/testify v0.0.0-20190311161405-34c6fa2dc709
+require (
+	github.com/stretchr/testify v1.6.1
+	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
+)

--- a/go.sum
+++ b/go.sum
@@ -4,14 +4,11 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v0.0.0-20190311161405-34c6fa2dc709 h1:zN7m1FsHm1PeW8oJ3JvZPC5Cc1lWnEiHtS1i6DpXcm0=
-github.com/stretchr/testify v0.0.0-20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/lint v0.0.0-20190409202823-959b441ac422 h1:QzoH/1pFpZguR8NrRHLcO6jKqfv2zpuSqZLgdm7ZmjI=
-golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
-golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -19,5 +16,7 @@ golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20190311212946-11955173bddd h1:/e+gpKk9r3dJobndpTytxS2gOy6m5uvpg+ISQoEcusQ=
-golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ring/gaussianSampler.go
+++ b/ring/gaussianSampler.go
@@ -34,7 +34,7 @@ func (context *Context) SampleGaussian(pol *Poly, sigma float64, bound uint64) {
 	}
 }
 
-// SampleGaussian samples a truncated gaussian polynomial with variance sigma within the given bound using the Ziggurat algorithm.
+// SampleGaussianAndAdd samples a truncated gaussian polynomial with variance sigma within the given bound using the Ziggurat algorithm.
 func (context *Context) SampleGaussianAndAdd(pol *Poly, sigma float64, bound uint64) {
 
 	var coeffFlo float64

--- a/ring/ntt.go
+++ b/ring/ntt.go
@@ -142,19 +142,21 @@ func InvNTT(coeffsIn, coeffsOut []uint64, N uint64, nttPsiInv []uint64, nttNInv,
 /// For benchmark purposes only ///
 ///////////////////////////////////
 
+// NTTBarrett computes the NTTBarrett of the Context
 func (context *Context) NTTBarrett(p1, p2 *Poly) {
 	for x := range context.Modulus {
 		NTTBarrett(p1.Coeffs[x], p2.Coeffs[x], context.N, context.nttPsi[x], context.Modulus[x], context.bredParams[x])
 	}
 }
 
+// InvNTTBarrett computes the InvNTTBarrett of the Context
 func (context *Context) InvNTTBarrett(p1, p2 *Poly) {
 	for x := range context.Modulus {
 		InvNTTBarrett(p1.Coeffs[x], p2.Coeffs[x], context.N, context.nttPsiInv[x], context.nttNInv[x], context.Modulus[x], context.bredParams[x])
 	}
 }
 
-// Butterfly computes X, Y = U + V*Psi, U - V*Psi mod Q.
+// ButterflyBarrett computes X, Y = U + V*Psi, U - V*Psi mod Q.
 func ButterflyBarrett(U, V, Psi, Q uint64, bredParams []uint64) (X, Y uint64) {
 	if U > 2*Q {
 		U -= 2 * Q
@@ -165,7 +167,7 @@ func ButterflyBarrett(U, V, Psi, Q uint64, bredParams []uint64) (X, Y uint64) {
 	return
 }
 
-// InvButterfly computes X, Y = U + V, (U - V) * Psi mod Q.
+// InvButterflyBarrett computes X, Y = U + V, (U - V) * Psi mod Q.
 func InvButterflyBarrett(U, V, Psi, Q uint64, bredParams []uint64) (X, Y uint64) {
 	X = U + V
 	if X > 2*Q {
@@ -175,7 +177,7 @@ func InvButterflyBarrett(U, V, Psi, Q uint64, bredParams []uint64) (X, Y uint64)
 	return
 }
 
-// NTT computes the NTT transformation on the input coefficients given the provided params.
+// NTTBarrett computes the NTT transformation on the input coefficients given the provided params.
 func NTTBarrett(coeffsIn, coeffsOut []uint64, N uint64, nttPsi []uint64, Q uint64, bredParams []uint64) {
 	var j1, j2, t uint64
 	var F uint64
@@ -211,7 +213,7 @@ func NTTBarrett(coeffsIn, coeffsOut []uint64, N uint64, nttPsi []uint64, Q uint6
 	}
 }
 
-// InvNTT computes the InvNTT transformation on the input coefficients given the provided params.
+// InvNTTBarrett computes the InvNTT transformation on the input coefficients given the provided params.
 func InvNTTBarrett(coeffsIn, coeffsOut []uint64, N uint64, nttPsiInv []uint64, nttNInv, Q uint64, bredParams []uint64) {
 
 	var j1, j2, h, t uint64

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -294,6 +294,7 @@ func (context *Context) MulCoeffsMontgomeryAndAddNoModLvl(level uint64, p1, p2, 
 	}
 }
 
+// MulCoeffsMontgomeryConstantAndAddNoModLvl is like MulCoeffsMontgomeryAndAddNoModLvl but in constant time
 func (context *Context) MulCoeffsMontgomeryConstantAndAddNoModLvl(level uint64, p1, p2, p3 *Poly) {
 	var qi uint64
 	for i := uint64(0); i < level+1; i++ {


### PR DESCRIPTION
Depends on #51 

* travis should build with the latest go version, it now do so, with 1.13 & 1.14 being the two supported version
* travis now can catch issues similar to #51
* the Makefile looked like an old copy of the one in dedis/Coding, using now upstream direclty
* fix the lint issues found by the new version of dedis/Coding