### PR TITLE
fix equality check of params of bfv and ckks

### DIFF
--- a/bfv/params.go
+++ b/bfv/params.go
@@ -200,7 +200,7 @@ func (p *Parameters) Equals(other *Parameters) (res bool) {
 		return true
 	}
 
-	res = res && (p.LogN == other.LogN)
+	res = p.LogN == other.LogN
 	res = res && (p.N == other.N)
 	res = res && (p.T == other.T)
 	res = res && (p.Sigma == other.Sigma)

--- a/bfv/params.go
+++ b/bfv/params.go
@@ -218,8 +218,6 @@ func (p *Parameters) Equals(other *Parameters) (res bool) {
 
 	res = res && (p.isValid == other.isValid)
 
-	fmt.Println(res)
-
 	return
 }
 

--- a/ckks/params.go
+++ b/ckks/params.go
@@ -201,7 +201,7 @@ func (p *Parameters) Equals(other *Parameters) (res bool) {
 		return true
 	}
 
-	res = res && (p.LogN == other.LogN)
+	res = p.LogN == other.LogN
 	res = res && (p.N == other.N)
 	res = res && (p.LogSlots == other.LogSlots)
 	res = res && (p.Slots == other.Slots)

--- a/ckks/params.go
+++ b/ckks/params.go
@@ -220,8 +220,6 @@ func (p *Parameters) Equals(other *Parameters) (res bool) {
 
 	res = res && (p.isValid == other.isValid)
 
-	fmt.Println(res)
-
 	return
 }
 


### PR DESCRIPTION
This fixes a bug in the equality check of the bfv and ckks parameters.
The boolean `res` defaults to false, thus if the pointers are not the same the result of equal was always false.

Also removed the println because it looks like it was forgotten (but maybe not, let me know).

PS: let me know if you have a different process than what I did for PRs