### PR TITLE
[ckks] API improvements and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 # Changelog
 All notable changes to this project will be documented in this file. 
 
+## [2.0.x] - 2020-11-20
+
+### Changed
+- CKKS : API of evaluator.RotateColumns becomes Evaluator.Rotate
+- CKKS : the change of variable in evaluator.EvaluateCheby isn't done automatically anymore and the user must do it before calling the function to ensure correctness. The reason is that additional constant might be merged with the change of variable and/or the change of variable might be merged with previous operations. This leaves more freedom to the user to optimize a circuit. The method also doesn't take anymore into account the change of variable for checking if the number of remaining levels is sufficient to evaluate the polynomial.
+- CKKS : when encoding, the number of slots must now be given in log2 basis. This is to prevent errors that would induced by zero values or non power of two values.
+- CKKS : new encoder API : EncodeAtLvlNew and EncodeNTTAtLvlNew, which allow a user to encode a plaintext at a specific level.
+
+### Removed
+- CKKS : evaluator.EvaluateChebySpecial
+
 ## [2.0.0] - 2020-10-07
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - CKKS : API of evaluator.RotateColumns becomes Evaluator.Rotate
-- CKKS : the change of variable in evaluator.EvaluateCheby isn't done automatically anymore and the user must do it before calling the function to ensure correctness. The reason is that additional constant might be merged with the change of variable and/or the change of variable might be merged with previous operations. This leaves more freedom to the user to optimize a circuit. The method also doesn't take anymore into account the change of variable for checking if the number of remaining levels is sufficient to evaluate the polynomial.
+- CKKS : the change of variable in evaluator.EvaluateCheby isn't done automatically anymore and the user must do it before calling the function to ensure correctness.
 - CKKS : when encoding, the number of slots must now be given in log2 basis. This is to prevent errors that would induced by zero values or non power of two values.
 - CKKS : new encoder API : EncodeAtLvlNew and EncodeNTTAtLvlNew, which allow a user to encode a plaintext at a specific level.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # Changelog
 All notable changes to this project will be documented in this file. 
 
-## [2.0.x] - 2020-11-20
+## Unreleased changes
 
 ### Changed
 - CKKS : API of evaluator.RotateColumns becomes Evaluator.Rotate

--- a/ckks/bootstrapp_test.go
+++ b/ckks/bootstrapp_test.go
@@ -73,9 +73,13 @@ func TestBootstrapp(t *testing.T) {
 				values[i] = sin2pi2pi(values[i])
 			}
 
+			eval.MultByConst(ciphertext, 2/(cheby.b-cheby.a), ciphertext)
+			eval.AddConst(ciphertext, (-cheby.a-cheby.b)/(cheby.b-cheby.a), ciphertext)
+			eval.Rescale(ciphertext, eval.(*evaluator).scale, ciphertext)
+
 			//fmt.Println(ciphertext.Level() - 1)
 			//start := time.Now()
-			if ciphertext, err = testContext.evaluator.EvaluateCheby(ciphertext, cheby, testContext.rlk); err != nil {
+			if ciphertext, err = eval.EvaluateCheby(ciphertext, cheby, testContext.rlk); err != nil {
 				t.Error(err)
 			}
 			//fmt.Printf("Elapsed : %s \n", time.Since(start))
@@ -130,21 +134,25 @@ func TestBootstrapp(t *testing.T) {
 				values[i] /= 6.283185307179586
 			}
 
-			testContext.evaluator.AddConst(ciphertext, -0.25, ciphertext)
+			eval.AddConst(ciphertext, -0.25, ciphertext)
+
+			eval.MultByConst(ciphertext, 2/((cheby.b-cheby.a)*scFac), ciphertext)
+			eval.AddConst(ciphertext, (-cheby.a-cheby.b)/(cheby.b-cheby.a), ciphertext)
+			eval.Rescale(ciphertext, eval.(*evaluator).scale, ciphertext)
 
 			//fmt.Println(ciphertext.Level(), ciphertext.Scale())
 			//start := time.Now()
-			if ciphertext, err = testContext.evaluator.EvaluateChebySpecial(ciphertext, scFac, cheby, testContext.rlk); err != nil {
+			if ciphertext, err = eval.EvaluateCheby(ciphertext, cheby, testContext.rlk); err != nil {
 				t.Error(err)
 			}
 			//fmt.Println(ciphertext.Level(), ciphertext.Scale())
 
 			for i := 0; i < scNum; i++ {
 				sqrt2pi *= sqrt2pi
-				testContext.evaluator.MulRelin(ciphertext, ciphertext, testContext.rlk, ciphertext)
-				testContext.evaluator.Add(ciphertext, ciphertext, ciphertext)
-				testContext.evaluator.AddConst(ciphertext, -sqrt2pi, ciphertext)
-				testContext.evaluator.Rescale(ciphertext, eval.(*evaluator).scale, ciphertext)
+				eval.MulRelin(ciphertext, ciphertext, testContext.rlk, ciphertext)
+				eval.Add(ciphertext, ciphertext, ciphertext)
+				eval.AddConst(ciphertext, -sqrt2pi, ciphertext)
+				eval.Rescale(ciphertext, eval.(*evaluator).scale, ciphertext)
 			}
 
 			//fmt.Printf("Elapsed : %s \n", time.Since(start))
@@ -195,19 +203,23 @@ func TestBootstrapp(t *testing.T) {
 
 			testContext.evaluator.AddConst(ciphertext, -0.25, ciphertext)
 
+			eval.MultByConst(ciphertext, 2/((cheby.b-cheby.a)*scFac), ciphertext)
+			eval.AddConst(ciphertext, (-cheby.a-cheby.b)/(cheby.b-cheby.a), ciphertext)
+			eval.Rescale(ciphertext, eval.(*evaluator).scale, ciphertext)
+
 			//fmt.Println(ciphertext.Level(), ciphertext.Scale())
 			//start := time.Now()
-			if ciphertext, err = testContext.evaluator.EvaluateChebySpecial(ciphertext, scFac, cheby, testContext.rlk); err != nil {
+			if ciphertext, err = eval.EvaluateCheby(ciphertext, cheby, testContext.rlk); err != nil {
 				t.Error(err)
 			}
 			//fmt.Println(ciphertext.Level(), ciphertext.Scale())
 
 			for i := 0; i < scNum; i++ {
 				sqrt2pi *= sqrt2pi
-				testContext.evaluator.MulRelin(ciphertext, ciphertext, testContext.rlk, ciphertext)
-				testContext.evaluator.Add(ciphertext, ciphertext, ciphertext)
-				testContext.evaluator.AddConst(ciphertext, -sqrt2pi, ciphertext)
-				testContext.evaluator.Rescale(ciphertext, eval.(*evaluator).scale, ciphertext)
+				eval.MulRelin(ciphertext, ciphertext, testContext.rlk, ciphertext)
+				eval.Add(ciphertext, ciphertext, ciphertext)
+				eval.AddConst(ciphertext, -sqrt2pi, ciphertext)
+				eval.Rescale(ciphertext, eval.(*evaluator).scale, ciphertext)
 			}
 
 			//fmt.Printf("Elapsed : %s \n", time.Since(start))

--- a/ckks/bootstrapp_test.go
+++ b/ckks/bootstrapp_test.go
@@ -50,7 +50,7 @@ func TestBootstrapp(t *testing.T) {
 			panic(err)
 		}
 
-		slots := testContext.params.Slots()
+		logSlots := testContext.params.LogSlots()
 
 		t.Run(testString(testContext, "ChebySin/"), func(t *testing.T) {
 
@@ -239,20 +239,20 @@ func TestBootstrapp(t *testing.T) {
 				panic(err)
 			}
 
-			values := make([]complex128, slots)
+			values := make([]complex128, 1<<logSlots)
 			for i := range values {
 				values[i] = complex(randomFloat(-1, 1), randomFloat(-1, 1))
 			}
 
 			values[0] = complex(0.9238795325112867, 0.3826834323650898)
 			values[1] = complex(0.9238795325112867, 0.3826834323650898)
-			if slots > 2 {
+			if 1<<logSlots > 2 {
 				values[2] = complex(0.9238795325112867, 0.3826834323650898)
 				values[3] = complex(0.9238795325112867, 0.3826834323650898)
 			}
 
 			plaintext := NewPlaintext(testContext.params, testContext.params.MaxLevel(), testContext.params.scale)
-			testContext.encoder.Encode(plaintext, values, slots)
+			testContext.encoder.Encode(plaintext, values, logSlots)
 
 			ciphertext := testContext.encryptorPk.EncryptNew(plaintext)
 
@@ -271,17 +271,17 @@ func TestBootstrapp(t *testing.T) {
 
 func newTestVectorsSineBootstrapp(testContext *testParams, encryptor Encryptor, a, b float64, t *testing.T) (values []complex128, plaintext *Plaintext, ciphertext *Ciphertext) {
 
-	slots := testContext.params.Slots()
+	logSlots := testContext.params.LogSlots()
 
-	values = make([]complex128, slots)
+	values = make([]complex128, 1<<logSlots)
 
-	for i := uint64(0); i < slots; i++ {
+	for i := uint64(0); i < 1<<logSlots; i++ {
 		values[i] = complex(math.Round(randomFloat(a, b))+randomFloat(-1, 1)/1000, 0)
 	}
 
 	plaintext = NewPlaintext(testContext.params, testContext.params.MaxLevel(), testContext.params.Scale())
 
-	testContext.encoder.EncodeNTT(plaintext, values, slots)
+	testContext.encoder.EncodeNTT(plaintext, values, logSlots)
 
 	if encryptor != nil {
 		ciphertext = encryptor.EncryptNew(plaintext)

--- a/ckks/bootstrapper.go
+++ b/ckks/bootstrapper.go
@@ -18,7 +18,8 @@ type Bootstrapper struct {
 	*BootstrappingKey
 	params *Parameters
 
-	dslots uint64 // Number of plaintext slots after the re-encoding
+	dslots    uint64 // Number of plaintext slots after the re-encoding
+	logdslots uint64
 
 	encoder   Encoder   // Encoder
 	evaluator Evaluator // Evaluator
@@ -102,9 +103,11 @@ func newBootstrapper(params *Parameters, btpParams *BootstrappParams) (btp *Boot
 	btp.BootstrappParams = *btpParams.Copy()
 
 	btp.dslots = params.Slots()
+	btp.logdslots = params.LogSlots()
 	if params.logSlots < params.MaxLogSlots() {
 		btp.repack = true
 		btp.dslots <<= 1
+		btp.logdslots++
 	}
 
 	btp.deviation = 1024.0
@@ -529,7 +532,7 @@ func (btp *Bootstrapper) encodePVec(pVec map[uint64][]complex128, plaintextVec *
 			//  levels * n coefficients of 8 bytes each
 			btp.plaintextSize += 8 * N * (level + 1 + btp.params.PiCount())
 
-			encoder.embed(rotate(pVec[N1*j+uint64(i)], (N>>1)-(N1*j))[:btp.dslots], btp.dslots)
+			encoder.embed(rotate(pVec[N1*j+uint64(i)], (N>>1)-(N1*j))[:btp.dslots], btp.logdslots)
 
 			plaintextQ := ring.NewPoly(N, level+1)
 			encoder.scaleUp(plaintextQ, scale, ringQ.Modulus[:level+1])

--- a/ckks/chebyshev_interpolation.go
+++ b/ckks/chebyshev_interpolation.go
@@ -11,6 +11,16 @@ type ChebyshevInterpolation struct {
 	b complex128
 }
 
+// A returns the start of the approximation interval.
+func (c *ChebyshevInterpolation) A() complex128 {
+	return c.a
+}
+
+// B returns the end of the approximation interval.
+func (c *ChebyshevInterpolation) B() complex128 {
+	return c.b
+}
+
 // Approximate computes a Chebyshev approximation of the input function, for the range [-a, b] of degree degree.
 // To be used in conjunction with the function EvaluateCheby.
 func Approximate(function func(complex128) complex128, a, b complex128, degree int) (cheby *ChebyshevInterpolation) {

--- a/ckks/ckks_benchmarks_test.go
+++ b/ckks/ckks_benchmarks_test.go
@@ -36,34 +36,34 @@ func BenchmarkCKKSScheme(b *testing.B) {
 func benchEncoder(testContext *testParams, b *testing.B) {
 
 	encoder := testContext.encoder
-	slots := testContext.params.Slots()
+	logSlots := testContext.params.LogSlots()
 
 	b.Run(testString(testContext, "Encoder/Encode/"), func(b *testing.B) {
 
-		values := make([]complex128, slots)
-		for i := uint64(0); i < slots; i++ {
+		values := make([]complex128, 1<<logSlots)
+		for i := uint64(0); i < 1<<logSlots; i++ {
 			values[i] = complex(randomFloat(-1, 1), randomFloat(-1, 1))
 		}
 
 		plaintext := NewPlaintext(testContext.params, testContext.params.MaxLevel(), testContext.params.Scale())
 
 		for i := 0; i < b.N; i++ {
-			encoder.Encode(plaintext, values, slots)
+			encoder.Encode(plaintext, values, logSlots)
 		}
 	})
 
 	b.Run(testString(testContext, "Encoder/Decode/"), func(b *testing.B) {
 
-		values := make([]complex128, slots)
-		for i := uint64(0); i < slots; i++ {
+		values := make([]complex128, 1<<logSlots)
+		for i := uint64(0); i < 1<<logSlots; i++ {
 			values[i] = complex(randomFloat(-1, 1), randomFloat(-1, 1))
 		}
 
 		plaintext := NewPlaintext(testContext.params, testContext.params.MaxLevel(), testContext.params.Scale())
-		encoder.Encode(plaintext, values, slots)
+		encoder.Encode(plaintext, values, logSlots)
 
 		for i := 0; i < b.N; i++ {
-			encoder.Decode(plaintext, slots)
+			encoder.Decode(plaintext, logSlots)
 		}
 	})
 }

--- a/ckks/ckks_benchmarks_test.go
+++ b/ckks/ckks_benchmarks_test.go
@@ -218,7 +218,7 @@ func benchEvaluator(testContext *testParams, b *testing.B) {
 
 	b.Run(testString(testContext, "Evaluator/Rotate/"), func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			evaluator.RotateColumns(ciphertext1, 1, rotkey, ciphertext1)
+			evaluator.Rotate(ciphertext1, 1, rotkey, ciphertext1)
 		}
 	})
 }

--- a/ckks/ckks_test.go
+++ b/ckks/ckks_test.go
@@ -144,11 +144,11 @@ func genTestParams(defaultParam *Parameters, hw uint64) (testContext *testParams
 
 func newTestVectors(testContext *testParams, encryptor Encryptor, a, b complex128, t *testing.T) (values []complex128, plaintext *Plaintext, ciphertext *Ciphertext) {
 
-	slots := testContext.params.Slots()
+	logSlots := testContext.params.LogSlots()
 
-	values = make([]complex128, slots)
+	values = make([]complex128, 1<<logSlots)
 
-	for i := uint64(0); i < slots; i++ {
+	for i := uint64(0); i < 1<<logSlots; i++ {
 		values[i] = complex(randomFloat(real(a), real(b)), randomFloat(imag(a), imag(b)))
 	}
 
@@ -156,7 +156,7 @@ func newTestVectors(testContext *testParams, encryptor Encryptor, a, b complex12
 
 	plaintext = NewPlaintext(testContext.params, testContext.params.MaxLevel(), testContext.params.Scale())
 
-	testContext.encoder.EncodeNTT(plaintext, values, slots)
+	testContext.encoder.EncodeNTT(plaintext, values, logSlots)
 
 	if encryptor != nil {
 		ciphertext = encryptor.EncryptNew(plaintext)
@@ -247,11 +247,11 @@ func testEncryptor(testContext *testParams, t *testing.T) {
 
 	t.Run(testString(testContext, "Encryptor/EncryptFromPkFast/"), func(t *testing.T) {
 
-		slots := testContext.params.Slots()
+		logSlots := testContext.params.LogSlots()
 
-		values := make([]complex128, slots)
+		values := make([]complex128, 1<<logSlots)
 
-		for i := uint64(0); i < slots; i++ {
+		for i := uint64(0); i < 1<<logSlots; i++ {
 			values[i] = randomComplex(-1, 1)
 		}
 
@@ -259,7 +259,7 @@ func testEncryptor(testContext *testParams, t *testing.T) {
 
 		plaintext := NewPlaintext(testContext.params, testContext.params.MaxLevel(), testContext.params.Scale())
 
-		testContext.encoder.Encode(plaintext, values, slots)
+		testContext.encoder.Encode(plaintext, values, logSlots)
 
 		verifyTestVectors(testContext, testContext.decryptor, values, testContext.encryptorPk.EncryptFastNew(plaintext), t)
 	})

--- a/ckks/encoder.go
+++ b/ckks/encoder.go
@@ -164,11 +164,7 @@ func (encoder *encoderComplex128) Embed(values []complex128, logSlots uint64) {
 
 	slots := uint64(1 << logSlots)
 
-	if uint64(len(values)) > encoder.params.N()/2 || uint64(len(values)) > slots {
-		panic("cannot Encode: too many values for the given number of slots")
-	}
-
-	if uint64(len(values)) > encoder.params.N()/2 || uint64(len(values)) > slots || slots > encoder.params.N()/2 {
+	if uint64(len(values)) > encoder.params.N()/2 || uint64(len(values)) > slots || logSlots > encoder.params.LogN()-1 {
 		panic("cannot Encode: too many values/slots for the given ring degree")
 	}
 
@@ -282,11 +278,11 @@ func (encoder *encoderComplex128) DecodeCoeffs(plaintext *Plaintext) (res []floa
 // Decode decodes the Plaintext values to a slice of complex128 values of size at most N/2.
 func (encoder *encoderComplex128) Decode(plaintext *Plaintext, logSlots uint64) (res []complex128) {
 
-	slots := uint64(1 << logSlots)
-
-	if slots > encoder.params.N()/2 {
+	if logSlots > encoder.params.LogN()-1 {
 		panic("cannot Decode: too many slots for the given ring degree")
 	}
+
+	slots := uint64(1 << logSlots)
 
 	if plaintext.isNTT {
 		encoder.ringQ.InvNTTLvl(plaintext.Level(), plaintext.value, encoder.polypool)
@@ -521,7 +517,7 @@ func (encoder *encoderBigComplex) Encode(plaintext *Plaintext, values []*ring.Co
 
 	slots := uint64(1 << logSlots)
 
-	if uint64(len(values)) > encoder.params.N()/2 || uint64(len(values)) > slots || slots > encoder.params.N()/2 {
+	if uint64(len(values)) > encoder.params.N()/2 || uint64(len(values)) > slots || logSlots > encoder.params.LogN()-1 {
 		panic("cannot Encode: too many values/slots for the given ring degree")
 	}
 
@@ -563,7 +559,7 @@ func (encoder *encoderBigComplex) Decode(plaintext *Plaintext, logSlots uint64) 
 
 	slots := uint64(1 << logSlots)
 
-	if slots > encoder.params.N()/2 {
+	if logSlots > encoder.params.LogN()-1 {
 		panic("cannot Decode: too many slots for the given ring degree")
 	}
 

--- a/ckks/evaluator.go
+++ b/ckks/evaluator.go
@@ -42,6 +42,7 @@ type Evaluator interface {
 	DropLevelNew(ct0 *Ciphertext, levels uint64) (ctOut *Ciphertext)
 	DropLevel(ct0 *Ciphertext, levels uint64) (err error)
 	Rescale(ct0 *Ciphertext, threshold float64, c1 *Ciphertext) (err error)
+	RescaleNew(ct0 *Ciphertext, threshold float64) (ctOut *Ciphertext, err error)
 	RescaleMany(ct0 *Ciphertext, nbRescales uint64, c1 *Ciphertext) (err error)
 	MulRelinNew(op0, op1 Operand, evakey *EvaluationKey) (ctOut *Ciphertext)
 	MulRelin(op0, op1 Operand, evakey *EvaluationKey, ctOut *Ciphertext)
@@ -1232,6 +1233,7 @@ func (eval *evaluator) DropLevel(ct0 *Ciphertext, levels uint64) (err error) {
 // in a newly created element. Since all the moduli in the moduli chain are generated to be close to the
 // original scale, this procedure is equivalent to dividing the input element by the scale and adding
 // some error.
+// Returns an error if "threshold <= 0", ct.Scale() = 0, ct.Level() = 0, ct.IsNTT() != true
 func (eval *evaluator) RescaleNew(ct0 *Ciphertext, threshold float64) (ctOut *Ciphertext, err error) {
 
 	ctOut = NewCiphertext(eval.params, ct0.Degree(), ct0.Level(), ct0.Scale())

--- a/ckks/polynomial_evaluation.go
+++ b/ckks/polynomial_evaluation.go
@@ -26,6 +26,9 @@ func NewPoly(coeffs []complex128) (p *Poly) {
 	return
 }
 
+// checkEnoughLevels checks that enough levels are available to evaluate the polynomial.
+// Also checks if c is a gaussian integer or not. If not, then one more level is needed
+// to evaluate the polynomial.
 func checkEnoughLevels(levels uint64, pol *Poly, c complex128) (err error) {
 
 	logDegree := uint64(math.Log2(float64(len(pol.coeffs))) + 0.5)
@@ -108,6 +111,7 @@ func (eval *evaluator) EvaluatePoly(ct0 *Ciphertext, pol *Poly, evakey *Evaluati
 // EvaluateCheby evaluates a polynomial in Chebyshev basis on the input Ciphertext in ceil(log2(deg+1))+1 levels.
 // Returns an error if the input ciphertext does not have enough level to carry out the full polynomial evaluation.
 // Returns an error if something is wrong with the scale.
+// A change of basis ct' = (2/(b-a)) * (ct + (-a-b)/(b-a)) is necessary before the polynomial evaluation to ensure correctness.
 func (eval *evaluator) EvaluateCheby(op *Ciphertext, cheby *ChebyshevInterpolation, evakey *EvaluationKey) (opOut *Ciphertext, err error) {
 
 	if err := checkEnoughLevels(op.Level(), &cheby.Poly, 1); err != nil {

--- a/ckks/polynomial_evaluation.go
+++ b/ckks/polynomial_evaluation.go
@@ -110,43 +110,13 @@ func (eval *evaluator) EvaluatePoly(ct0 *Ciphertext, pol *Poly, evakey *Evaluati
 // Returns an error if something is wrong with the scale.
 func (eval *evaluator) EvaluateCheby(op *Ciphertext, cheby *ChebyshevInterpolation, evakey *EvaluationKey) (opOut *Ciphertext, err error) {
 
-	if err := checkEnoughLevels(op.Level(), &cheby.Poly, 2/(cheby.b-cheby.a)); err != nil {
+	if err := checkEnoughLevels(op.Level(), &cheby.Poly, 1); err != nil {
 		return op, err
 	}
 
 	C := make(map[uint64]*Ciphertext)
 
 	C[1] = op.CopyNew().Ciphertext()
-
-	eval.MultByConst(C[1], 2/(cheby.b-cheby.a), C[1])
-	eval.AddConst(C[1], (-cheby.a-cheby.b)/(cheby.b-cheby.a), C[1])
-	eval.Rescale(C[1], eval.scale, C[1])
-
-	return eval.evalCheby(cheby, C, evakey)
-}
-
-// EvaluateChebyFastSpecial evaluates the input Chebyshev polynomial with the input ciphertext.
-// Slower than EvaluateChebyFast but consumes ceil(log(deg)) + 1 levels.
-// Returns an error if the input ciphertext does not have enough level to carry out the full polynomial evaluation.
-// Returns an error if something is wrong with the scale.
-func (eval *evaluator) EvaluateChebySpecial(op *Ciphertext, n complex128, cheby *ChebyshevInterpolation, evakey *EvaluationKey) (opOut *Ciphertext, err error) {
-
-	if err := checkEnoughLevels(op.Level(), &cheby.Poly, 2/((cheby.b-cheby.a)*n)); err != nil {
-		return op, err
-	}
-
-	C := make(map[uint64]*Ciphertext)
-
-	C[1] = op.CopyNew().Ciphertext()
-
-	eval.MultByConst(C[1], 2/((cheby.b-cheby.a)*n), C[1])
-	eval.AddConst(C[1], (-cheby.a-cheby.b)/(cheby.b-cheby.a), C[1])
-	eval.Rescale(C[1], eval.scale, C[1])
-
-	return eval.evalCheby(cheby, C, evakey)
-}
-
-func (eval *evaluator) evalCheby(cheby *ChebyshevInterpolation, C map[uint64]*Ciphertext, evakey *EvaluationKey) (opOut *Ciphertext, err error) {
 
 	logDegree := uint64(bits.Len64(cheby.Degree()))
 	logSplit := (logDegree >> 1) //optimalSplit(logDegree) //
@@ -497,7 +467,7 @@ func evaluatePolyFromPowerBasis(targetScale float64, coeffs *Poly, C map[uint64]
 			cReal := int64(real(coeffs.coeffs[key]) * constScale)
 			cImag := int64(imag(coeffs.coeffs[key]) * constScale)
 
-			evaluator.multByGaussianIntegerAndAdd(C[key], cReal, cImag, res)
+			evaluator.MultByGaussianIntegerAndAdd(C[key], cReal, cImag, res)
 		}
 	}
 

--- a/ckks/precision.go
+++ b/ckks/precision.go
@@ -37,13 +37,14 @@ func GetPrecisionStats(params *Parameters, encoder Encoder, decryptor Decryptor,
 
 	var valuesTest []complex128
 
-	slots := params.Slots()
+	logSlots := params.LogSlots()
+	slots := uint64(1 << logSlots)
 
 	switch element.(type) {
 	case *Ciphertext:
-		valuesTest = encoder.Decode(decryptor.DecryptNew(element.(*Ciphertext)), slots)
+		valuesTest = encoder.Decode(decryptor.DecryptNew(element.(*Ciphertext)), logSlots)
 	case *Plaintext:
-		valuesTest = encoder.Decode(element.(*Plaintext), slots)
+		valuesTest = encoder.Decode(element.(*Plaintext), logSlots)
 	case []complex128:
 		valuesTest = element.([]complex128)
 	}
@@ -52,7 +53,7 @@ func GetPrecisionStats(params *Parameters, encoder Encoder, decryptor Decryptor,
 
 	var delta complex128
 
-	diff := make([]complex128, params.Slots())
+	diff := make([]complex128, slots)
 
 	prec.MaxDelta = complex(0, 0)
 	prec.MinDelta = complex(1, 1)
@@ -107,7 +108,7 @@ func GetPrecisionStats(params *Parameters, encoder Encoder, decryptor Decryptor,
 
 	prec.MinPrecision = deltaToPrecision(prec.MaxDelta)
 	prec.MaxPrecision = deltaToPrecision(prec.MinDelta)
-	prec.MeanDelta /= complex(float64(params.Slots()), 0)
+	prec.MeanDelta /= complex(float64(slots), 0)
 	prec.MeanPrecision = deltaToPrecision(prec.MeanDelta)
 	prec.MedianDelta = calcmedian(diff)
 	prec.MedianPrecision = deltaToPrecision(prec.MedianDelta)

--- a/dckks/dckks_test.go
+++ b/dckks/dckks_test.go
@@ -523,7 +523,7 @@ func testRotKeyGenCols(testCtx *testContext, t *testing.T) {
 			rotkey := ckks.NewRotationKeys()
 			P0.Finalize(testCtx.params, P0.share, crp, rotkey)
 
-			evaluator.RotateColumns(ciphertext, k, rotkey, receiver)
+			evaluator.Rotate(ciphertext, k, rotkey, receiver)
 
 			coeffsWant := make([]complex128, ringQP.N>>1)
 
@@ -684,9 +684,7 @@ func newTestVectors(testCtx *testContext, encryptor ckks.Encryptor, a float64, t
 
 	values[0] = complex(0.607538, 0.555668)
 
-	plaintext = ckks.NewPlaintext(testCtx.params, testCtx.params.MaxLevel(), testCtx.params.Scale())
-
-	testCtx.encoder.Encode(plaintext, values, slots)
+	plaintext = testCtx.encoder.EncodeNew(values, testCtx.params.LogSlots())
 
 	ciphertext = encryptor.EncryptNew(plaintext)
 
@@ -707,7 +705,7 @@ func verifyTestVectors(testCtx *testContext, decryptor ckks.Decryptor, valuesWan
 
 	slots := testCtx.params.Slots()
 
-	valuesTest = testCtx.encoder.Decode(plaintextTest, slots)
+	valuesTest = testCtx.encoder.Decode(plaintextTest, testCtx.params.LogSlots())
 
 	var deltaReal, deltaImag float64
 

--- a/examples/ckks/bootstrapping/main.go
+++ b/examples/ckks/bootstrapping/main.go
@@ -64,8 +64,7 @@ func main() {
 		valuesWant[i] = randomComplex(-1, 1)
 	}
 
-	plaintext = ckks.NewPlaintext(params, params.MaxLevel(), params.Scale())
-	encoder.Encode(plaintext, valuesWant, params.Slots())
+	plaintext = encoder.EncodeNew(valuesWant, params.LogSlots())
 
 	// Encrypt
 	ciphertext1 := encryptor.EncryptNew(plaintext)
@@ -93,9 +92,7 @@ func main() {
 
 func printDebug(params *ckks.Parameters, ciphertext *ckks.Ciphertext, valuesWant []complex128, decryptor ckks.Decryptor, encoder ckks.Encoder) (valuesTest []complex128) {
 
-	slots := uint64(len(valuesWant))
-
-	valuesTest = encoder.Decode(decryptor.DecryptNew(ciphertext), slots)
+	valuesTest = encoder.Decode(decryptor.DecryptNew(ciphertext), params.LogSlots())
 
 	fmt.Println()
 	fmt.Printf("Level: %d (logQ = %d)\n", ciphertext.Level(), params.LogQLvl(ciphertext.Level()))

--- a/examples/ckks/euler/main.go
+++ b/examples/ckks/euler/main.go
@@ -78,7 +78,7 @@ func example() {
 	}
 
 	plaintext := ckks.NewPlaintext(params, params.MaxLevel(), params.Scale()/r)
-	encoder.Encode(plaintext, values, slots)
+	encoder.Encode(plaintext, values, params.LogSlots())
 
 	fmt.Printf("Done in %s \n", time.Since(start))
 
@@ -191,7 +191,7 @@ func example() {
 
 	start = time.Now()
 
-	encoder.Decode(decryptor.DecryptNew(ciphertext), slots)
+	encoder.Decode(decryptor.DecryptNew(ciphertext), params.LogSlots())
 
 	fmt.Printf("Done in %s \n", time.Since(start))
 
@@ -201,9 +201,7 @@ func example() {
 
 func printDebug(params *ckks.Parameters, ciphertext *ckks.Ciphertext, valuesWant []complex128, decryptor ckks.Decryptor, encoder ckks.Encoder) (valuesTest []complex128) {
 
-	slots := uint64(len(valuesWant))
-
-	valuesTest = encoder.Decode(decryptor.DecryptNew(ciphertext), slots)
+	valuesTest = encoder.Decode(decryptor.DecryptNew(ciphertext), params.LogSlots())
 
 	fmt.Println()
 	fmt.Printf("Level: %d (logQ = %d)\n", ciphertext.Level(), params.LogQLvl(ciphertext.Level()))


### PR DESCRIPTION
API changes :

- evaluator.RotateColumns -> Evaluator.Rotate
- evaluator.EvaluateChebySpecial -> removed
- evaluator.EvaluateCheby -> the change of variable isn't done automatically anymore and the user must do it before calling the function to ensure correctness. The reason is that additional constant might be merged with the change of variable and/or the change of variable might be merged with previous operations. This leaves more freedom to the user to optimize a circuit. The method also doesn't take anymore into account the change of variable for checking if the number of remaining levels is sufficient to evaluate the polynomial.
- encoder : when encoding, the number of slots must now be given in log2 basis. This is to prevent errors that would induced by zero values or non power of two values.
- encoder : added EncodeAtLvlNew and EncodeNTTAtLvlNew API

- Updated change-log to reflect the aforementioned changes.


