### PR TITLE
fix issue #121

### DIFF
--- a/ckks/utils.go
+++ b/ckks/utils.go
@@ -81,6 +81,15 @@ func scaleUpVecExact(values []float64, n float64, moduli []uint64, coeffs [][]ui
 			}
 		}
 	}
+
+	if len(values) < len(coeffs[0]) {
+		for i := range moduli {
+			tmp := coeffs[i]
+			for j := len(values); j < len(coeffs[0]); j++ {
+				tmp[j] = 0
+			}
+		}
+	}
 }
 
 func scaleUpVecExactBigFloat(values []*big.Float, scale float64, moduli []uint64, coeffs [][]uint64) {


### PR DESCRIPTION
ckks : fixed scale up exact to set the remaining values of [][]coeffs to zero if input slice to scale has a smaller size