### PR TITLE
Improve concurrency compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,12 @@ All notable changes to this project will be documented in this file.
 - CKKS: added `.ShallowCopy()` to `Encoder` and `EncoderBigComplex`.
 - CKKS: added `ShallowCopy()`, `.WithKey()` (shallow copy with new key) and `.SetKey()` to `Encryptor` and `Decryptor`.
 - DRLWE: added `.ShallowCopy()` for all protocols.
-- DBFV: added `.ShallowCopy()` for all protocols.
+- DRLWE: `GenShare(*)` of `CKSProtocol` and `PCKSProtocol` now only take as input a polynomial instead of the full ciphertext.
+- DBFV: updated `PCKSProtocol` and `CKSProtocol` API consistency, updated tests and benchmarks accordingly.
+- DBFV: protocols using `drlwe.CKSProtocol` or `drlwe.PCKSProtocol` as sub-protocols now only take a polynomial as input instead of the full ciphertext.
 - DCKKS: added `.ShallowCopy()` for all protocols.
+- DCKKS: updated `PCKSProtocol` and `CKSProtocol` API consistency, updated tests and benchmarks accordingly.
+- DCKKS: protocols using `drlwe.CKSProtocol` or `drlwe.PCKSProtocol` as sub-protocols now only take a polynomial as input instead of the full ciphertext.
 
 ## [2.4.0] - 2022-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ All notable changes to this project will be documented in this file.
 
 - RING: renamed `FastBasisExtender` to `BasisExtender`.
 - RLWE: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) and `.SetKey()` to `Encryptor` and `Decryptor`.
-- BFV: added `.ShallowCopy()` for `Encoder`.
+- RLWE: removed `FastEncryptor`. Encryption without rescaling by `P` is now automatically used by `Encryptor` if no `P` is specified in the parameters.
+- BFV: added `.ShallowCopy()` to `Encoder`.
 - BFV: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) and `.SetKey()` to `Encryptor` and `Decryptor`.
-- CKKS: added `.ShallowCopy()` for `Encoder` and `EncoderBigComplex`.
+- CKKS: added `.ShallowCopy()` to `Encoder` and `EncoderBigComplex`.
 - CKKS: added `ShallowCopy()`, `.WithKey()` (shallow copy with new key) and `.SetKey()` to `Encryptor` and `Decryptor`.
 - DRLWE: added `.ShallowCopy()` for all protocols.
 - DBFV: added `.ShallowCopy()` for all protocols.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 - RLWE/CKKS/BFV: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) to `Encryptor` and `Decryptor`.
 - BFV/CKKS: added `.ShallowCopy()` to `Encoder` and `EncoderBigComplex` (only CKKS).
 - DRLWE/DCKKS/DBFV: added `.ShallowCopy()` to all protocols.
-- DLRWE/DCKKS/DBFV: protocols `drlwe.CKSProtocol` or `drlwe.PCKSProtocol` and sub-protocols based on these two protocols now only take a polynomial as input instead of the full ciphertext.
+- DLRWE/DCKKS/DBFV: protocols `drlwe.CKSProtocol` and `drlwe.PCKSProtocol` and sub-protocols based on these two protocols now only take a polynomial as input for the share generation instead of the full ciphertext.
 - DRLWE/DCKKS/DBFV: uniformized API of share generation and aggregation to `.GenShare(*)` and `.AggregateShare(*)`.
 
 ## [2.4.0] - 2022-01-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 # Changelog
 All notable changes to this project will be documented in this file. 
 
+
+## Unreleased
+
+- RING: renamed `FastBasisExtender` to `BasisExtender`.
+- RLWE: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) and `.SetKey()` to `Encryptor` and `Decryptor`.
+- BFV: added `.ShallowCopy()` for `Encoder`.
+- BFV: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) and `.SetKey()` to `Encryptor` and `Decryptor`.
+- CKKS: added `.ShallowCopy()` for `Encoder` and `EncoderBigComplex`.
+- CKKS: added `ShallowCopy()`, `.WithKey()` (shallow copy with new key) and `.SetKey()` to `Encryptor` and `Decryptor`.
+- DRLWE: added `.ShallowCopy()` for all protocols.
+- DBFV: added `.ShallowCopy()` for all protocols.
+- DCKKS: added `.ShallowCopy()` for all protocols.
+
 ## [2.4.0] - 2022-01-10
 
 - RING: added support for ring operations over the conjugate invariant ring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,14 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - RING: renamed `FastBasisExtender` to `BasisExtender`.
-- RING: `.PolyToBigint[...]` now take as input `gap` which defines the multiples of `X^{i*gap}` to reconstruct.
-- RLWE: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) to `Encryptor` and `Decryptor`.
+- RING: `.PolyToBigint[...](*)` now take as input `gap` which defines the multiples of `X^{i*gap}` to reconstruct.
 - RLWE: removed `FastEncryptor`. Encryption without rescaling by `P` is now automatically used by `Encryptor` if no `P` is specified in the parameters.
 - RLWE: `NewAdditiveShareBigint` now takes as input the size of the share.
-- BFV: added `.ShallowCopy()` to `Encoder`.
-- BFV: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) to `Encryptor` and `Decryptor`.
-- CKKS: added `.ShallowCopy()` to `Encoder` and `EncoderBigComplex`.
-- CKKS: added `ShallowCopy()`, `.WithKey()` (shallow copy with new key) to `Encryptor` and `Decryptor`.
-- DRLWE: added `.ShallowCopy()` for all protocols.
-- DRLWE: `GenShare(*)` of `CKSProtocol` and `PCKSProtocol` now only take as input a polynomial instead of the full ciphertext.
-- DBFV: protocols using `drlwe.CKSProtocol` or `drlwe.PCKSProtocol` as sub-protocols now only take a polynomial as input instead of the full ciphertext.
-- DCKKS: added `.ShallowCopy()` for all protocols.
-- DCKKS: updated `PCKSProtocol` and `CKSProtocol` API consistency, updated tests and benchmarks accordingly.
-- DCKKS: protocols using `drlwe.CKSProtocol` or `drlwe.PCKSProtocol` as sub-protocols now only take a polynomial as input instead of the full ciphertext.
-- DRLWE/DCKKS/DBFV: uniformized API of share generation and aggregation to `.GenShare(*)` and `.AggregateShare`.
+- RLWE/CKKS/BFV: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) to `Encryptor` and `Decryptor`.
+- BFV/CKKS: added `.ShallowCopy()` to `Encoder` and `EncoderBigComplex` (only CKKS).
+- DRLWE/DCKKS/DBFV: added `.ShallowCopy()` to all protocols.
+- DLRWE/DCKKS/DBFV: protocols `drlwe.CKSProtocol` or `drlwe.PCKSProtocol` and sub-protocols based on these two protocols now only take a polynomial as input instead of the full ciphertext.
+- DRLWE/DCKKS/DBFV: uniformized API of share generation and aggregation to `.GenShare(*)` and `.AggregateShare(*)`.
 
 ## [2.4.0] - 2022-01-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,21 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 - RING: renamed `FastBasisExtender` to `BasisExtender`.
-- RLWE: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) and `.SetKey()` to `Encryptor` and `Decryptor`.
+- RING: `.PolyToBigint[...]` now take as input `gap` which defines the multiples of `X^{i*gap}` to reconstruct.
+- RLWE: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) to `Encryptor` and `Decryptor`.
 - RLWE: removed `FastEncryptor`. Encryption without rescaling by `P` is now automatically used by `Encryptor` if no `P` is specified in the parameters.
+- RLWE: `NewAdditiveShareBigint` now takes as input the size of the share.
 - BFV: added `.ShallowCopy()` to `Encoder`.
-- BFV: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) and `.SetKey()` to `Encryptor` and `Decryptor`.
+- BFV: added `.ShallowCopy()`, `.WithKey()` (shallow copy with new key) to `Encryptor` and `Decryptor`.
 - CKKS: added `.ShallowCopy()` to `Encoder` and `EncoderBigComplex`.
-- CKKS: added `ShallowCopy()`, `.WithKey()` (shallow copy with new key) and `.SetKey()` to `Encryptor` and `Decryptor`.
+- CKKS: added `ShallowCopy()`, `.WithKey()` (shallow copy with new key) to `Encryptor` and `Decryptor`.
 - DRLWE: added `.ShallowCopy()` for all protocols.
 - DRLWE: `GenShare(*)` of `CKSProtocol` and `PCKSProtocol` now only take as input a polynomial instead of the full ciphertext.
-- DBFV: updated `PCKSProtocol` and `CKSProtocol` API consistency, updated tests and benchmarks accordingly.
 - DBFV: protocols using `drlwe.CKSProtocol` or `drlwe.PCKSProtocol` as sub-protocols now only take a polynomial as input instead of the full ciphertext.
 - DCKKS: added `.ShallowCopy()` for all protocols.
 - DCKKS: updated `PCKSProtocol` and `CKSProtocol` API consistency, updated tests and benchmarks accordingly.
 - DCKKS: protocols using `drlwe.CKSProtocol` or `drlwe.PCKSProtocol` as sub-protocols now only take a polynomial as input instead of the full ciphertext.
+- DRLWE/DCKKS/DBFV: uniformized API of share generation and aggregation to `.GenShare(*)` and `.AggregateShare`.
 
 ## [2.4.0] - 2022-01-10
 

--- a/bfv/bfv_benchmark_test.go
+++ b/bfv/bfv_benchmark_test.go
@@ -106,26 +106,14 @@ func benchKeyGen(testctx *testContext, b *testing.B) {
 func benchEncrypt(testctx *testContext, b *testing.B) {
 
 	encryptorPk := testctx.encryptorPk
-	encryptorPkFast := NewFastEncryptor(testctx.params, testctx.pk)
 	encryptorSk := testctx.encryptorSk
 
 	plaintext := NewPlaintext(testctx.params)
 	ciphertext := NewCiphertextRandom(testctx.prng, testctx.params, 1)
 
 	b.Run(testString("Encrypt/key=Pk/", testctx.params), func(b *testing.B) {
-
-		if testctx.params.PCount() == 0 {
-			b.Skip("#Pi is empty")
-		}
-
 		for i := 0; i < b.N; i++ {
 			encryptorPk.Encrypt(plaintext, ciphertext)
-		}
-	})
-
-	b.Run(testString("EncryptFast/key=Pk/", testctx.params), func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			encryptorPkFast.Encrypt(plaintext, ciphertext)
 		}
 	})
 

--- a/bfv/decryptor.go
+++ b/bfv/decryptor.go
@@ -10,7 +10,6 @@ type Decryptor interface {
 	Decrypt(ciphertext *Ciphertext, plaintext *Plaintext)
 	ShallowCopy() Decryptor
 	WithKey(sk *rlwe.SecretKey) Decryptor
-	SetKey(sk *rlwe.SecretKey)
 }
 
 type decryptor struct {

--- a/bfv/decryptor.go
+++ b/bfv/decryptor.go
@@ -10,6 +10,7 @@ type Decryptor interface {
 	Decrypt(ciphertext *Ciphertext, plaintext *Plaintext)
 	ShallowCopy() Decryptor
 	WithKey(sk *rlwe.SecretKey) Decryptor
+	SetKey(sk *rlwe.SecretKey)
 }
 
 type decryptor struct {
@@ -23,27 +24,27 @@ func NewDecryptor(params Parameters, sk *rlwe.SecretKey) Decryptor {
 }
 
 // Decrypt decrypts the ciphertext and write the result in ptOut.
-func (d *decryptor) Decrypt(ct *Ciphertext, ptOut *Plaintext) {
-	d.Decryptor.Decrypt(&rlwe.Ciphertext{Value: ct.Value}, &rlwe.Plaintext{Value: ptOut.Value})
+func (dec *decryptor) Decrypt(ct *Ciphertext, ptOut *Plaintext) {
+	dec.Decryptor.Decrypt(&rlwe.Ciphertext{Value: ct.Value}, &rlwe.Plaintext{Value: ptOut.Value})
 }
 
 // DecryptNew decrypts the ciphertext and returns the result in a newly allocated Plaintext.
-func (d *decryptor) DecryptNew(ct *Ciphertext) (ptOut *Plaintext) {
-	pt := NewPlaintext(d.params)
-	d.Decryptor.Decrypt(ct.Ciphertext, pt.Plaintext)
+func (dec *decryptor) DecryptNew(ct *Ciphertext) (ptOut *Plaintext) {
+	pt := NewPlaintext(dec.params)
+	dec.Decryptor.Decrypt(ct.Ciphertext, pt.Plaintext)
 	return pt
 }
 
 // ShallowCopy creates a shallow copy of Decryptor in which all the read-only data-structures are
 // shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
 // Decryptor can be used concurrently.
-func (d *decryptor) ShallowCopy() Decryptor {
-	return &decryptor{d.Decryptor.ShallowCopy(), d.params}
+func (dec *decryptor) ShallowCopy() Decryptor {
+	return &decryptor{dec.Decryptor.ShallowCopy(), dec.params}
 }
 
 // WithKey creates a shallow copy of Decryptor with a new decryption key, in which all the
 // read-only data-structures are shared with the receiver and the temporary buffers
 // are reallocated. The receiver and the returned Decryptor can be used concurrently.
-func (d *decryptor) WithKey(sk *rlwe.SecretKey) Decryptor {
-	return &decryptor{d.Decryptor.WithKey(sk), d.params}
+func (dec *decryptor) WithKey(sk *rlwe.SecretKey) Decryptor {
+	return &decryptor{dec.Decryptor.WithKey(sk), dec.params}
 }

--- a/bfv/encoder.go
+++ b/bfv/encoder.go
@@ -54,6 +54,8 @@ type Encoder interface {
 	DecodeInt(pt interface{}, coeffs []int64)
 	DecodeUintNew(pt interface{}) (coeffs []uint64)
 	DecodeIntNew(pt interface{}) (coeffs []int64)
+
+	ShallowCopy() Encoder
 }
 
 // Encoder is a structure that stores the parameters to encode values on a plaintext in a SIMD (Single-Instruction Multiple-Data) fashion.

--- a/bfv/encoder.go
+++ b/bfv/encoder.go
@@ -148,7 +148,7 @@ func (ecd *encoder) EncodeUintRingT(coeffs []uint64, p *PlaintextRingT) {
 	ecd.params.RingT().InvNTT(p.Value, p.Value)
 }
 
-// EncodeUintMul encodes an uint64 slice of size at most N on a PlaintextRingT (R_t) optimized for ciphertext x plaintext multiplication.
+// EncodeUintMul encodes an uint64 slice of size at most N on a PlaintextRingT (R_t) optimized for ciphertext-plaintext multiplication.
 func (ecd *encoder) EncodeUintMul(coeffs []uint64, p *PlaintextMul) {
 
 	ptRt := &PlaintextRingT{p.Plaintext}
@@ -160,7 +160,7 @@ func (ecd *encoder) EncodeUintMul(coeffs []uint64, p *PlaintextMul) {
 	ecd.RingTToMul(ptRt, p)
 }
 
-// EncodeInt encodes an int64 slice of size at most N on a plaintext. It also encodes the sign of the given integer (as its inverse modulo the plaintext modulus).
+// EncodeIntRingT encodes an int64 slice of size at most N on a plaintext. It also encodes the sign of the given integer (as its inverse modulo the plaintext modulus).
 // The sign will correctly decode as long as the absolute value of the coefficient does not exceed half of the plaintext modulus.
 func (ecd *encoder) EncodeIntRingT(coeffs []int64, p *PlaintextRingT) {
 
@@ -323,7 +323,7 @@ func (ecd *encoder) ShallowCopy() Encoder {
 	}
 }
 
-// takes m mod T and returns round((m*Q)/T) mod Q
+// scaleUp takes m mod T and returns round((m*Q)/T) mod Q
 func (ecd *encoder) scaleUp(ringQ, ringT *ring.Ring, tmp []uint64, pIn, pOut *ring.Poly) {
 
 	qModTmontgomery := ring.MForm(new(big.Int).Mod(ringQ.ModulusBigint, ringT.ModulusBigint).Uint64(), ringT.Modulus[0], ringT.BredParams[0])

--- a/bfv/encoder.go
+++ b/bfv/encoder.go
@@ -71,20 +71,6 @@ type encoder struct {
 	tmpPtRt *PlaintextRingT
 }
 
-// ShallowCopy creates a shallow copy of Encoder in which all the read-only data-structures are
-// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
-// Encoder can be used concurrently.
-func (ecd *encoder) ShallowCopy() Encoder {
-	return &encoder{
-		params:        ecd.params,
-		indexMatrix:   ecd.indexMatrix,
-		scaler:        ring.NewRNSScaler(ecd.params.RingQ(), ecd.params.RingT()),
-		rescaleParams: ecd.rescaleParams,
-		tmpPoly:       ecd.params.RingT().NewPoly(),
-		tmpPtRt:       NewPlaintextRingT(ecd.params),
-	}
-}
-
 // NewEncoder creates a new encoder from the provided parameters.
 func NewEncoder(params Parameters) Encoder {
 
@@ -130,6 +116,17 @@ func NewEncoder(params Parameters) Encoder {
 	}
 }
 
+// EncodeUint encodes an uint64 slice of size at most N on a plaintext.
+func (ecd *encoder) EncodeUint(coeffs []uint64, p *Plaintext) {
+	ptRt := &PlaintextRingT{p.Plaintext}
+
+	// Encodes the values in RingT
+	ecd.EncodeUintRingT(coeffs, ptRt)
+
+	// Scales by Q/t
+	ecd.ScaleUp(ptRt, p)
+}
+
 // EncodeUintRingT encodes a slice of uint64 into a Plaintext in R_t
 func (ecd *encoder) EncodeUintRingT(coeffs []uint64, p *PlaintextRingT) {
 	if len(coeffs) > len(ecd.indexMatrix) {
@@ -151,17 +148,7 @@ func (ecd *encoder) EncodeUintRingT(coeffs []uint64, p *PlaintextRingT) {
 	ecd.params.RingT().InvNTT(p.Value, p.Value)
 }
 
-// EncodeUint encodes an uint64 slice of size at most N on a plaintext.
-func (ecd *encoder) EncodeUint(coeffs []uint64, p *Plaintext) {
-	ptRt := &PlaintextRingT{p.Plaintext}
-
-	// Encodes the values in RingT
-	ecd.EncodeUintRingT(coeffs, ptRt)
-
-	// Scales by Q/t
-	ecd.ScaleUp(ptRt, p)
-}
-
+// EncodeUintMul encodes an uint64 slice of size at most N on a PlaintextRingT (R_t) optimized for ciphertext x plaintext multiplication.
 func (ecd *encoder) EncodeUintMul(coeffs []uint64, p *PlaintextMul) {
 
 	ptRt := &PlaintextRingT{p.Plaintext}
@@ -201,6 +188,7 @@ func (ecd *encoder) EncodeIntRingT(coeffs []int64, p *PlaintextRingT) {
 	ecd.params.RingT().InvNTTLazy(p.Value, p.Value)
 }
 
+// EncodeInt encodes an int64 slice of size at most N on a plaintext.
 func (ecd *encoder) EncodeInt(coeffs []int64, p *Plaintext) {
 	ptRt := &PlaintextRingT{p.Plaintext}
 
@@ -211,6 +199,7 @@ func (ecd *encoder) EncodeInt(coeffs []int64, p *Plaintext) {
 	ecd.ScaleUp(ptRt, p)
 }
 
+// EncodeIntMul encodes an int64 slice of size at most N on a PlaintextRingT (R_t) optimized for ciphertext-plaintext multiplication.
 func (ecd *encoder) EncodeIntMul(coeffs []int64, p *PlaintextMul) {
 	ptRt := &PlaintextRingT{p.Plaintext}
 
@@ -224,58 +213,6 @@ func (ecd *encoder) EncodeIntMul(coeffs []int64, p *PlaintextMul) {
 // ScaleUp transforms a PlaintextRingT (R_t) into a Plaintext (R_q) by scaling up the coefficient by Q/t.
 func (ecd *encoder) ScaleUp(ptRt *PlaintextRingT, pt *Plaintext) {
 	ecd.scaleUp(ecd.params.RingQ(), ecd.params.RingT(), ecd.tmpPoly.Coeffs[0], ptRt.Value, pt.Value)
-}
-
-// takes m mod T and returns round((m*Q)/T) mod Q
-func (ecd *encoder) scaleUp(ringQ, ringT *ring.Ring, tmp []uint64, pIn, pOut *ring.Poly) {
-
-	qModTmontgomery := ring.MForm(new(big.Int).Mod(ringQ.ModulusBigint, ringT.ModulusBigint).Uint64(), ringT.Modulus[0], ringT.BredParams[0])
-
-	t := ringT.Modulus[0]
-	tHalf := t >> 1
-	tInv := ringT.MredParams[0]
-
-	// (x * Q + T/2) mod T
-	for i := 0; i < ringQ.N; i = i + 8 {
-		x := (*[8]uint64)(unsafe.Pointer(&pIn.Coeffs[0][i]))
-		z := (*[8]uint64)(unsafe.Pointer(&tmp[i]))
-
-		z[0] = ring.CRed(ring.MRed(x[0], qModTmontgomery, t, tInv)+tHalf, t)
-		z[1] = ring.CRed(ring.MRed(x[1], qModTmontgomery, t, tInv)+tHalf, t)
-		z[2] = ring.CRed(ring.MRed(x[2], qModTmontgomery, t, tInv)+tHalf, t)
-		z[3] = ring.CRed(ring.MRed(x[3], qModTmontgomery, t, tInv)+tHalf, t)
-		z[4] = ring.CRed(ring.MRed(x[4], qModTmontgomery, t, tInv)+tHalf, t)
-		z[5] = ring.CRed(ring.MRed(x[5], qModTmontgomery, t, tInv)+tHalf, t)
-		z[6] = ring.CRed(ring.MRed(x[6], qModTmontgomery, t, tInv)+tHalf, t)
-		z[7] = ring.CRed(ring.MRed(x[7], qModTmontgomery, t, tInv)+tHalf, t)
-	}
-
-	// (x * T^-1 - T/2) mod Qi
-	for i := 0; i < len(pOut.Coeffs); i++ {
-		p0tmp := tmp
-		p1tmp := pOut.Coeffs[i]
-		qi := ringQ.Modulus[i]
-		bredParams := ringQ.BredParams[i]
-		mredParams := ringQ.MredParams[i]
-		rescaleParams := qi - ecd.rescaleParams[i]
-
-		tHalfNegQi := qi - ring.BRedAdd(tHalf, qi, bredParams)
-
-		for j := 0; j < ringQ.N; j = j + 8 {
-
-			x := (*[8]uint64)(unsafe.Pointer(&p0tmp[j]))
-			z := (*[8]uint64)(unsafe.Pointer(&p1tmp[j]))
-
-			z[0] = ring.MRed(x[0]+tHalfNegQi, rescaleParams, qi, mredParams)
-			z[1] = ring.MRed(x[1]+tHalfNegQi, rescaleParams, qi, mredParams)
-			z[2] = ring.MRed(x[2]+tHalfNegQi, rescaleParams, qi, mredParams)
-			z[3] = ring.MRed(x[3]+tHalfNegQi, rescaleParams, qi, mredParams)
-			z[4] = ring.MRed(x[4]+tHalfNegQi, rescaleParams, qi, mredParams)
-			z[5] = ring.MRed(x[5]+tHalfNegQi, rescaleParams, qi, mredParams)
-			z[6] = ring.MRed(x[6]+tHalfNegQi, rescaleParams, qi, mredParams)
-			z[7] = ring.MRed(x[7]+tHalfNegQi, rescaleParams, qi, mredParams)
-		}
-	}
 }
 
 // ScaleDown transforms a Plaintext (R_q) into a PlaintextRingT (R_t) by scaling down the coefficient by t/Q and rounding.
@@ -370,4 +307,70 @@ func (ecd *encoder) DecodeIntNew(p interface{}) (coeffs []int64) {
 	coeffs = make([]int64, ecd.params.RingQ().N)
 	ecd.DecodeInt(p, coeffs)
 	return
+}
+
+// ShallowCopy creates a shallow copy of Encoder in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Encoder can be used concurrently.
+func (ecd *encoder) ShallowCopy() Encoder {
+	return &encoder{
+		params:        ecd.params,
+		indexMatrix:   ecd.indexMatrix,
+		scaler:        ring.NewRNSScaler(ecd.params.RingQ(), ecd.params.RingT()),
+		rescaleParams: ecd.rescaleParams,
+		tmpPoly:       ecd.params.RingT().NewPoly(),
+		tmpPtRt:       NewPlaintextRingT(ecd.params),
+	}
+}
+
+// takes m mod T and returns round((m*Q)/T) mod Q
+func (ecd *encoder) scaleUp(ringQ, ringT *ring.Ring, tmp []uint64, pIn, pOut *ring.Poly) {
+
+	qModTmontgomery := ring.MForm(new(big.Int).Mod(ringQ.ModulusBigint, ringT.ModulusBigint).Uint64(), ringT.Modulus[0], ringT.BredParams[0])
+
+	t := ringT.Modulus[0]
+	tHalf := t >> 1
+	tInv := ringT.MredParams[0]
+
+	// (x * Q + T/2) mod T
+	for i := 0; i < ringQ.N; i = i + 8 {
+		x := (*[8]uint64)(unsafe.Pointer(&pIn.Coeffs[0][i]))
+		z := (*[8]uint64)(unsafe.Pointer(&tmp[i]))
+
+		z[0] = ring.CRed(ring.MRed(x[0], qModTmontgomery, t, tInv)+tHalf, t)
+		z[1] = ring.CRed(ring.MRed(x[1], qModTmontgomery, t, tInv)+tHalf, t)
+		z[2] = ring.CRed(ring.MRed(x[2], qModTmontgomery, t, tInv)+tHalf, t)
+		z[3] = ring.CRed(ring.MRed(x[3], qModTmontgomery, t, tInv)+tHalf, t)
+		z[4] = ring.CRed(ring.MRed(x[4], qModTmontgomery, t, tInv)+tHalf, t)
+		z[5] = ring.CRed(ring.MRed(x[5], qModTmontgomery, t, tInv)+tHalf, t)
+		z[6] = ring.CRed(ring.MRed(x[6], qModTmontgomery, t, tInv)+tHalf, t)
+		z[7] = ring.CRed(ring.MRed(x[7], qModTmontgomery, t, tInv)+tHalf, t)
+	}
+
+	// (x * T^-1 - T/2) mod Qi
+	for i := 0; i < len(pOut.Coeffs); i++ {
+		p0tmp := tmp
+		p1tmp := pOut.Coeffs[i]
+		qi := ringQ.Modulus[i]
+		bredParams := ringQ.BredParams[i]
+		mredParams := ringQ.MredParams[i]
+		rescaleParams := qi - ecd.rescaleParams[i]
+
+		tHalfNegQi := qi - ring.BRedAdd(tHalf, qi, bredParams)
+
+		for j := 0; j < ringQ.N; j = j + 8 {
+
+			x := (*[8]uint64)(unsafe.Pointer(&p0tmp[j]))
+			z := (*[8]uint64)(unsafe.Pointer(&p1tmp[j]))
+
+			z[0] = ring.MRed(x[0]+tHalfNegQi, rescaleParams, qi, mredParams)
+			z[1] = ring.MRed(x[1]+tHalfNegQi, rescaleParams, qi, mredParams)
+			z[2] = ring.MRed(x[2]+tHalfNegQi, rescaleParams, qi, mredParams)
+			z[3] = ring.MRed(x[3]+tHalfNegQi, rescaleParams, qi, mredParams)
+			z[4] = ring.MRed(x[4]+tHalfNegQi, rescaleParams, qi, mredParams)
+			z[5] = ring.MRed(x[5]+tHalfNegQi, rescaleParams, qi, mredParams)
+			z[6] = ring.MRed(x[6]+tHalfNegQi, rescaleParams, qi, mredParams)
+			z[7] = ring.MRed(x[7]+tHalfNegQi, rescaleParams, qi, mredParams)
+		}
+	}
 }

--- a/bfv/encryptor.go
+++ b/bfv/encryptor.go
@@ -11,7 +11,6 @@ type Encryptor interface {
 	EncryptNew(plaintext *Plaintext) *Ciphertext
 	EncryptFromCRP(plaintext *Plaintext, crp *ring.Poly, ctOut *Ciphertext)
 	EncryptFromCRPNew(plaintext *Plaintext, crp *ring.Poly) *Ciphertext
-
 	ShallowCopy() Encryptor
 	WithKey(key interface{}) Encryptor
 }

--- a/bfv/encryptor.go
+++ b/bfv/encryptor.go
@@ -21,21 +21,17 @@ type encryptor struct {
 }
 
 // NewEncryptor instantiates a new Encryptor for the BFV scheme. The key argument can
-// be either a *rlwe.PublicKey or a *rlwe.SecretKey.
+// be *rlwe.PublicKey, *rlwe.SecretKey or nil.
 func NewEncryptor(params Parameters, key interface{}) Encryptor {
 	return &encryptor{rlwe.NewEncryptor(params.Parameters, key), params}
 }
 
 // Encrypt encrypts the input plaintext and write the result on ctOut.
-// The encryption algorithm depends on how the receiver encryptor was initialized (see
-// NewEncryptor and NewFastEncryptor).
 func (enc *encryptor) Encrypt(plaintext *Plaintext, ctOut *Ciphertext) {
 	enc.Encryptor.Encrypt(&rlwe.Plaintext{Value: plaintext.Value}, &rlwe.Ciphertext{Value: ctOut.Value})
 }
 
 // EncryptNew encrypts the input plaintext returns the result as a newly allocated ciphertext.
-// The encryption algorithm depends on how the receiver encryptor was initialized (see
-// NewEncryptor and NewFastEncryptor).
 func (enc *encryptor) EncryptNew(plaintext *Plaintext) *Ciphertext {
 	ct := NewCiphertext(enc.params, 1)
 	enc.Encryptor.Encrypt(plaintext.Plaintext, ct.Ciphertext)
@@ -43,12 +39,16 @@ func (enc *encryptor) EncryptNew(plaintext *Plaintext) *Ciphertext {
 }
 
 // EncryptFromCRP encrypts the input plaintext and writes the result in ctOut.
+// This method of encryption only works if the encryptor has been instantiated with
+// a secret key.
 // The passed crp is always treated as being in the NTT domain.
 func (enc *encryptor) EncryptFromCRP(plaintext *Plaintext, crp *ring.Poly, ctOut *Ciphertext) {
 	enc.Encryptor.EncryptFromCRP(&rlwe.Plaintext{Value: plaintext.Value}, crp, &rlwe.Ciphertext{Value: ctOut.Value})
 }
 
 // EncryptFromCRPNew encrypts the input plaintext and returns the result as a newly allocated ciphertext.
+// This method of encryption only works if the encryptor has been instantiated with
+// a secret key.
 // The passed crp is always treated as being in the NTT domain.
 func (enc *encryptor) EncryptFromCRPNew(plaintext *Plaintext, crp *ring.Poly) *Ciphertext {
 	ct := NewCiphertext(enc.params, 1)
@@ -63,8 +63,10 @@ func (enc *encryptor) ShallowCopy() Encryptor {
 	return &encryptor{enc.Encryptor.ShallowCopy(), enc.params}
 }
 
-// WithKey creates a shallow copy of the receiver Encryptor with the provided key.
-// This is equivalent to calling Encryptor.ShallowCopy().WithKey(*)
+// ShallowCopy creates a shallow copy of this encryptor with a new key in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Encryptors can be used concurrently.
+// Key can be *rlwe.PublicKey or *rlwe.SecretKey.
 func (enc *encryptor) WithKey(key interface{}) Encryptor {
 	return &encryptor{enc.Encryptor.WithKey(key), enc.params}
 }

--- a/bfv/encryptor.go
+++ b/bfv/encryptor.go
@@ -11,6 +11,10 @@ type Encryptor interface {
 	EncryptNew(plaintext *Plaintext) *Ciphertext
 	EncryptFromCRP(plaintext *Plaintext, crp *ring.Poly, ctOut *Ciphertext)
 	EncryptFromCRPNew(plaintext *Plaintext, crp *ring.Poly) *Ciphertext
+
+	ShallowCopy() Encryptor
+	WithKey(key interface{}) Encryptor
+	SetKey(key interface{}) Encryptor
 }
 
 type encryptor struct {
@@ -52,4 +56,22 @@ func (enc *encryptor) EncryptFromCRPNew(plaintext *Plaintext, crp *ring.Poly) *C
 	ct := NewCiphertext(enc.params, 1)
 	enc.Encryptor.EncryptFromCRP(&rlwe.Plaintext{Value: plaintext.Value}, crp, ct.Ciphertext)
 	return ct
+}
+
+// ShallowCopy creates a shallow copy of this encryptor in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Encryptors can be used concurrently.
+func (enc *encryptor) ShallowCopy() Encryptor {
+	return &encryptor{enc.Encryptor.ShallowCopy(), enc.params}
+}
+
+// WithKey creates a shallow copy of the receiver Encryptor with the provided key.
+// This is equivalent to calling Encryptor.ShallowCopy().WithKey(*)
+func (enc *encryptor) WithKey(key interface{}) Encryptor {
+	return &encryptor{enc.Encryptor.WithKey(key), enc.params}
+}
+
+// SetKey sets the key of the target encryptor. Either secret-key, public-key or nil can be passed as argument.
+func (enc *encryptor) SetKey(key interface{}) Encryptor {
+	return &encryptor{enc.Encryptor.SetKey(key), enc.params}
 }

--- a/bfv/encryptor.go
+++ b/bfv/encryptor.go
@@ -24,13 +24,6 @@ func NewEncryptor(params Parameters, key interface{}) Encryptor {
 	return &encryptor{rlwe.NewEncryptor(params.Parameters, key), params}
 }
 
-// NewFastEncryptor instantiates a new Encryptor for the BFV scheme.
-// This encryptor's Encrypt method first encrypts zero in Q and then adds the plaintext.
-// This method is faster than the normal encryptor but result in a noisier ciphertext.
-func NewFastEncryptor(params Parameters, key *rlwe.PublicKey) Encryptor {
-	return &encryptor{rlwe.NewFastEncryptor(params.Parameters, key), params}
-}
-
 // Encrypt encrypts the input plaintext and write the result on ctOut.
 // The encryption algorithm depends on how the receiver encryptor was initialized (see
 // NewEncryptor and NewFastEncryptor).

--- a/bfv/encryptor.go
+++ b/bfv/encryptor.go
@@ -63,7 +63,7 @@ func (enc *encryptor) ShallowCopy() Encryptor {
 	return &encryptor{enc.Encryptor.ShallowCopy(), enc.params}
 }
 
-// ShallowCopy creates a shallow copy of this encryptor with a new key in which all the read-only data-structures are
+// WithKey creates a shallow copy of this encryptor with a new key in which all the read-only data-structures are
 // shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
 // Encryptors can be used concurrently.
 // Key can be *rlwe.PublicKey or *rlwe.SecretKey.

--- a/bfv/encryptor.go
+++ b/bfv/encryptor.go
@@ -14,7 +14,6 @@ type Encryptor interface {
 
 	ShallowCopy() Encryptor
 	WithKey(key interface{}) Encryptor
-	SetKey(key interface{}) Encryptor
 }
 
 type encryptor struct {
@@ -69,9 +68,4 @@ func (enc *encryptor) ShallowCopy() Encryptor {
 // This is equivalent to calling Encryptor.ShallowCopy().WithKey(*)
 func (enc *encryptor) WithKey(key interface{}) Encryptor {
 	return &encryptor{enc.Encryptor.WithKey(key), enc.params}
-}
-
-// SetKey sets the key of the target encryptor. Either secret-key, public-key or nil can be passed as argument.
-func (enc *encryptor) SetKey(key interface{}) Encryptor {
-	return &encryptor{enc.Encryptor.SetKey(key), enc.params}
 }

--- a/bfv/evaluator.go
+++ b/bfv/evaluator.go
@@ -693,7 +693,7 @@ func (eval *evaluator) ShallowCopy() Evaluator {
 	}
 }
 
-// ShallowCopyWithKey creates a shallow copy of this evaluator in which the read-only data-structures are
+// WithKey creates a shallow copy of this evaluator in which the read-only data-structures are
 // shared with the receiver but the EvaluationKey is evaluationKey.
 func (eval *evaluator) WithKey(evaluationKey rlwe.EvaluationKey) Evaluator {
 	return &evaluator{

--- a/bfv/evaluator.go
+++ b/bfv/evaluator.go
@@ -152,32 +152,6 @@ func NewEvaluators(params Parameters, evaluationKey rlwe.EvaluationKey, n int) [
 	return evas
 }
 
-// ShallowCopy creates a shallow copy of this evaluator in which the read-only data-structures are
-// shared with the receiver.
-func (eval *evaluator) ShallowCopy() Evaluator {
-	return &evaluator{
-		evaluatorBase:       eval.evaluatorBase,
-		KeySwitcher:         eval.KeySwitcher.ShallowCopy(),
-		evaluatorBuffers:    newEvaluatorBuffer(eval.evaluatorBase),
-		basisExtenderQ1toQ2: eval.basisExtenderQ1toQ2.ShallowCopy(),
-		rlk:                 eval.rlk,
-		rtks:                eval.rtks,
-	}
-}
-
-// ShallowCopyWithKey creates a shallow copy of this evaluator in which the read-only data-structures are
-// shared with the receiver but the EvaluationKey is evaluationKey.
-func (eval *evaluator) WithKey(evaluationKey rlwe.EvaluationKey) Evaluator {
-	return &evaluator{
-		evaluatorBase:       eval.evaluatorBase,
-		KeySwitcher:         eval.KeySwitcher,
-		evaluatorBuffers:    eval.evaluatorBuffers,
-		basisExtenderQ1toQ2: eval.basisExtenderQ1toQ2,
-		rlk:                 evaluationKey.Rlk,
-		rtks:                evaluationKey.Rtks,
-	}
-}
-
 // Add adds op0 to op1 and returns the result in ctOut.
 func (eval *evaluator) Add(op0, op1 Operand, ctOut *Ciphertext) {
 	el0, el1, elOut := eval.getElemAndCheckBinary(op0, op1, ctOut, utils.MaxInt(op0.Degree(), op1.Degree()), true)
@@ -704,6 +678,32 @@ func (eval *evaluator) InnerSum(ct0 *Ciphertext, ctOut *Ciphertext) {
 
 	eval.RotateRows(ctOut, cTmp)
 	eval.Add(ctOut, cTmp, ctOut)
+}
+
+// ShallowCopy creates a shallow copy of this evaluator in which the read-only data-structures are
+// shared with the receiver.
+func (eval *evaluator) ShallowCopy() Evaluator {
+	return &evaluator{
+		evaluatorBase:       eval.evaluatorBase,
+		KeySwitcher:         eval.KeySwitcher.ShallowCopy(),
+		evaluatorBuffers:    newEvaluatorBuffer(eval.evaluatorBase),
+		basisExtenderQ1toQ2: eval.basisExtenderQ1toQ2.ShallowCopy(),
+		rlk:                 eval.rlk,
+		rtks:                eval.rtks,
+	}
+}
+
+// ShallowCopyWithKey creates a shallow copy of this evaluator in which the read-only data-structures are
+// shared with the receiver but the EvaluationKey is evaluationKey.
+func (eval *evaluator) WithKey(evaluationKey rlwe.EvaluationKey) Evaluator {
+	return &evaluator{
+		evaluatorBase:       eval.evaluatorBase,
+		KeySwitcher:         eval.KeySwitcher,
+		evaluatorBuffers:    eval.evaluatorBuffers,
+		basisExtenderQ1toQ2: eval.basisExtenderQ1toQ2,
+		rlk:                 evaluationKey.Rlk,
+		rtks:                evaluationKey.Rtks,
+	}
 }
 
 // permute performs a column rotation on ct0 and returns the result in ctOut

--- a/bfv/utils.go
+++ b/bfv/utils.go
@@ -12,7 +12,7 @@ func DecryptAndPrintError(ptWant *Plaintext, cthave *Ciphertext, ringQ *ring.Rin
 	ringQ.Sub(cthave.Value[0], ptWant.Value, cthave.Value[0])
 	plaintext := decryptor.DecryptNew(cthave)
 	bigintCoeffs := make([]*big.Int, ringQ.N)
-	ringQ.PolyToBigint(plaintext.Value, bigintCoeffs)
+	ringQ.PolyToBigint(plaintext.Value, 1, bigintCoeffs)
 	center(bigintCoeffs, ringQ.ModulusBigint)
 	stdErr, minErr, maxErr := errorStats(bigintCoeffs)
 	fmt.Printf("STD : %f - Min : %f - Max : %f\n", math.Log2(stdErr), math.Log2(minErr), math.Log2(maxErr))

--- a/ckks/ckks_benchmarks_test.go
+++ b/ckks/ckks_benchmarks_test.go
@@ -99,24 +99,34 @@ func benchKeyGen(tc *testContext, b *testing.B) {
 
 func benchEncrypt(tc *testContext, b *testing.B) {
 
+<<<<<<< HEAD
 	encryptorPk := tc.encryptorPk
 	encryptorPkFast := NewFastEncryptor(tc.params, tc.pk)
 	encryptorSk := tc.encryptorSk
+=======
+	encryptorPk := testContext.encryptorPk
+	encryptorSk := testContext.encryptorSk
+>>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 
 	plaintext := NewPlaintext(tc.params, tc.params.MaxLevel(), tc.params.DefaultScale())
 	ciphertext := NewCiphertext(tc.params, 1, tc.params.MaxLevel(), tc.params.DefaultScale())
 
+<<<<<<< HEAD
 	b.Run(GetTestName(tc.params, "Encrypt/key=Pk/"), func(b *testing.B) {
 
 		if tc.params.PCount() == 0 {
 			b.Skip("#Pi is empty")
 		}
 
+=======
+	b.Run(GetTestName(testContext.params, "Encrypt/key=Pk/"), func(b *testing.B) {
+>>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 		for i := 0; i < b.N; i++ {
 			encryptorPk.Encrypt(plaintext, ciphertext)
 		}
 	})
 
+<<<<<<< HEAD
 	b.Run(GetTestName(tc.params, "EncryptFast/key=Pk/"), func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			encryptorPkFast.Encrypt(plaintext, ciphertext)
@@ -124,6 +134,9 @@ func benchEncrypt(tc *testContext, b *testing.B) {
 	})
 
 	b.Run(GetTestName(tc.params, "Encrypt/key=Sk/"), func(b *testing.B) {
+=======
+	b.Run(GetTestName(testContext.params, "Encrypt/key=Sk/"), func(b *testing.B) {
+>>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 		for i := 0; i < b.N; i++ {
 			encryptorSk.Encrypt(plaintext, ciphertext)
 		}

--- a/ckks/ckks_benchmarks_test.go
+++ b/ckks/ckks_benchmarks_test.go
@@ -99,44 +99,19 @@ func benchKeyGen(tc *testContext, b *testing.B) {
 
 func benchEncrypt(tc *testContext, b *testing.B) {
 
-<<<<<<< HEAD
 	encryptorPk := tc.encryptorPk
-	encryptorPkFast := NewFastEncryptor(tc.params, tc.pk)
 	encryptorSk := tc.encryptorSk
-=======
-	encryptorPk := testContext.encryptorPk
-	encryptorSk := testContext.encryptorSk
->>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 
 	plaintext := NewPlaintext(tc.params, tc.params.MaxLevel(), tc.params.DefaultScale())
 	ciphertext := NewCiphertext(tc.params, 1, tc.params.MaxLevel(), tc.params.DefaultScale())
 
-<<<<<<< HEAD
 	b.Run(GetTestName(tc.params, "Encrypt/key=Pk/"), func(b *testing.B) {
-
-		if tc.params.PCount() == 0 {
-			b.Skip("#Pi is empty")
-		}
-
-=======
-	b.Run(GetTestName(testContext.params, "Encrypt/key=Pk/"), func(b *testing.B) {
->>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 		for i := 0; i < b.N; i++ {
 			encryptorPk.Encrypt(plaintext, ciphertext)
 		}
 	})
 
-<<<<<<< HEAD
-	b.Run(GetTestName(tc.params, "EncryptFast/key=Pk/"), func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			encryptorPkFast.Encrypt(plaintext, ciphertext)
-		}
-	})
-
 	b.Run(GetTestName(tc.params, "Encrypt/key=Sk/"), func(b *testing.B) {
-=======
-	b.Run(GetTestName(testContext.params, "Encrypt/key=Sk/"), func(b *testing.B) {
->>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 		for i := 0; i < b.N; i++ {
 			encryptorSk.Encrypt(plaintext, ciphertext)
 		}

--- a/ckks/decryptor.go
+++ b/ckks/decryptor.go
@@ -10,6 +10,7 @@ type Decryptor interface {
 	Decrypt(ciphertext *Ciphertext, plaintext *Plaintext)
 	ShallowCopy() Decryptor
 	WithKey(sk *rlwe.SecretKey) Decryptor
+	SetKey(sk *rlwe.SecretKey)
 }
 type decryptor struct {
 	rlwe.Decryptor
@@ -37,13 +38,13 @@ func (dec *decryptor) Decrypt(ciphertext *Ciphertext, plaintext *Plaintext) {
 // ShallowCopy creates a shallow copy of Decryptor in which all the read-only data-structures are
 // shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
 // Decryptor can be used concurrently.
-func (d *decryptor) ShallowCopy() Decryptor {
-	return &decryptor{d.Decryptor.ShallowCopy(), d.params}
+func (dec *decryptor) ShallowCopy() Decryptor {
+	return &decryptor{dec.Decryptor.ShallowCopy(), dec.params}
 }
 
 // WithKey creates a shallow copy of Decryptor with a new decryption key, in which all the
 // read-only data-structures are shared with the receiver and the temporary buffers
 // are reallocated. The receiver and the returned Decryptor can be used concurrently.
-func (d *decryptor) WithKey(sk *rlwe.SecretKey) Decryptor {
-	return &decryptor{d.Decryptor.WithKey(sk), d.params}
+func (dec *decryptor) WithKey(sk *rlwe.SecretKey) Decryptor {
+	return &decryptor{dec.Decryptor.WithKey(sk), dec.params}
 }

--- a/ckks/decryptor.go
+++ b/ckks/decryptor.go
@@ -8,6 +8,8 @@ import (
 type Decryptor interface {
 	DecryptNew(ciphertext *Ciphertext) (plaintext *Plaintext)
 	Decrypt(ciphertext *Ciphertext, plaintext *Plaintext)
+	ShallowCopy() Decryptor
+	WithKey(sk *rlwe.SecretKey) Decryptor
 }
 type decryptor struct {
 	rlwe.Decryptor
@@ -30,4 +32,18 @@ func (dec *decryptor) DecryptNew(ciphertext *Ciphertext) (plaintext *Plaintext) 
 func (dec *decryptor) Decrypt(ciphertext *Ciphertext, plaintext *Plaintext) {
 	dec.Decryptor.Decrypt(&rlwe.Ciphertext{Value: ciphertext.Value}, &rlwe.Plaintext{Value: plaintext.Value})
 	plaintext.Scale = ciphertext.Scale
+}
+
+// ShallowCopy creates a shallow copy of Decryptor in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Decryptor can be used concurrently.
+func (d *decryptor) ShallowCopy() Decryptor {
+	return &decryptor{d.Decryptor.ShallowCopy(), d.params}
+}
+
+// WithKey creates a shallow copy of Decryptor with a new decryption key, in which all the
+// read-only data-structures are shared with the receiver and the temporary buffers
+// are reallocated. The receiver and the returned Decryptor can be used concurrently.
+func (d *decryptor) WithKey(sk *rlwe.SecretKey) Decryptor {
+	return &decryptor{d.Decryptor.WithKey(sk), d.params}
 }

--- a/ckks/decryptor.go
+++ b/ckks/decryptor.go
@@ -10,7 +10,6 @@ type Decryptor interface {
 	Decrypt(ciphertext *Ciphertext, plaintext *Plaintext)
 	ShallowCopy() Decryptor
 	WithKey(sk *rlwe.SecretKey) Decryptor
-	SetKey(sk *rlwe.SecretKey)
 }
 type decryptor struct {
 	rlwe.Decryptor

--- a/ckks/encoder.go
+++ b/ckks/encoder.go
@@ -267,7 +267,7 @@ func (ecd *encoderComplex128) DecodeCoeffsPublic(plaintext *Plaintext, sigma flo
 }
 
 // GetErrSTDCoeffDomain returns StandardDeviation(Encode(valuesWant-valuesHave))*scale
-// Which is the scaled standard deviation in the coefficient domain of the difference
+// which is the scaled standard deviation in the coefficient domain of the difference
 // of two complex vector in the slot domain.
 func (ecd *encoderComplex128) GetErrSTDCoeffDomain(valuesWant, valuesHave []complex128, scale float64) (std float64) {
 
@@ -291,7 +291,7 @@ func (ecd *encoderComplex128) GetErrSTDCoeffDomain(valuesWant, valuesHave []comp
 }
 
 // GetErrSTDSlotDomain returns StandardDeviation(valuesWant-valuesHave)*scale
-// Which is the scaled standard deviation of two complex vectors.
+// which is the scaled standard deviation of two complex vectors.
 func (ecd *encoderComplex128) GetErrSTDSlotDomain(valuesWant, valuesHave []complex128, scale float64) (std float64) {
 	var err complex128
 	for i := range valuesWant {

--- a/ckks/encoder.go
+++ b/ckks/encoder.go
@@ -85,9 +85,9 @@ type encoderComplex128 struct {
 	roots       []complex128
 }
 
-// ShallowCopy creates a shallow copy of EncoderBigComplex in which all the read-only data-structures are
+// ShallowCopy creates a shallow copy of encoder in which all the read-only data-structures are
 // shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
-// EncoderBigComplex can be used concurrently.
+// encoder can be used concurrently.
 func (ecd *encoder) ShallowCopy() *encoder {
 
 	prng, err := utils.NewPRNG()
@@ -302,7 +302,7 @@ func (ecd *encoderComplex128) GetErrSTDSlotDomain(valuesWant, valuesHave []compl
 	return StandardDeviation(ecd.valuesFloat[:len(valuesWant)*2], scale)
 }
 
-// ShallowCopy creates a shallow copy of this Encoder in which all the read-only data-structures are
+// ShallowCopy creates a shallow copy of this encoderComplex128 in which all the read-only data-structures are
 // shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
 // Encoder can be used concurrently.
 func (ecd *encoderComplex128) ShallowCopy() Encoder {
@@ -872,7 +872,7 @@ func (ecd *encoderBigComplex) InvFFT(values []*ring.Complex, N int) {
 	SliceBitReverseInPlaceRingComplex(values, N)
 }
 
-// ShallowCopy creates a shallow copy of this EncoderBigComplex in which all the read-only data-structures are
+// ShallowCopy creates a shallow copy of this encoderBigComplex in which all the read-only data-structures are
 // shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
 // EncoderBigComplex can be used concurrently.
 func (ecd *encoderBigComplex) ShallowCopy() EncoderBigComplex {

--- a/ckks/encoder.go
+++ b/ckks/encoder.go
@@ -124,6 +124,11 @@ type Encoder interface {
 	// GetErrSTDSlotDomain returns StandardDeviation(valuesWant-valuesHave)*scale
 	// Which is the scaled standard deviation of two complex vectors.
 	GetErrSTDSlotDomain(valuesWant, valuesHave []complex128, scale float64) (std float64)
+
+	// ShallowCopy creates a shallow copy of this Encoder in which all the read-only data-structures are
+	// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+	// Encoder can be used concurrently.
+	ShallowCopy() Encoder
 }
 
 // EncoderBigComplex is an interface that implements the encoding algorithms with arbitrary precision.
@@ -147,6 +152,11 @@ type EncoderBigComplex interface {
 
 	// InvFFT evaluates the encoding matrix on a slice of ring.Complex values.
 	InvFFT(values []*ring.Complex, N int)
+
+	// ShallowCopy creates a shallow copy of this EncoderBigComplex in which all the read-only data-structures are
+	// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+	// EncoderBigComplex can be used concurrently.
+	ShallowCopy() EncoderBigComplex
 }
 
 // encoder is a struct storing the necessary parameters to encode a slice of complex number on a Plaintext.
@@ -167,6 +177,34 @@ type encoderComplex128 struct {
 	values      []complex128
 	valuesFloat []float64
 	roots       []complex128
+}
+
+func (ecd *encoder) ShallowCopy() *encoder {
+
+	prng, err := utils.NewPRNG()
+	if err != nil {
+		panic(err)
+	}
+
+	return &encoder{
+		params:          ecd.params,
+		bigintChain:     ecd.bigintChain,
+		bigintCoeffs:    make([]*big.Int, ecd.m>>1),
+		qHalf:           ring.NewUint(0),
+		polypool:        ecd.params.RingQ().NewPoly(),
+		m:               ecd.m,
+		rotGroup:        ecd.rotGroup,
+		gaussianSampler: ring.NewGaussianSampler(prng, ecd.params.RingQ(), ecd.params.Sigma(), int(6*ecd.params.Sigma())),
+	}
+}
+
+func (ecd *encoderComplex128) ShallowCopy() Encoder {
+	return &encoderComplex128{
+		encoder:     *ecd.encoder.ShallowCopy(),
+		values:      make([]complex128, len(ecd.values)),
+		valuesFloat: make([]float64, len(ecd.valuesFloat)),
+		roots:       ecd.roots,
+	}
 }
 
 func newEncoder(params Parameters) encoder {
@@ -203,50 +241,50 @@ func newEncoder(params Parameters) encoder {
 // NewEncoder creates a new Encoder that is used to encode a slice of complex values of size at most N/2 (the number of slots) on a Plaintext.
 func NewEncoder(params Parameters) Encoder {
 
-	encoder := newEncoder(params)
+	ecd := newEncoder(params)
 
 	var angle float64
-	roots := make([]complex128, encoder.m+1)
-	for i := 0; i < encoder.m; i++ {
-		angle = 2 * 3.141592653589793 * float64(i) / float64(encoder.m)
+	roots := make([]complex128, ecd.m+1)
+	for i := 0; i < ecd.m; i++ {
+		angle = 2 * 3.141592653589793 * float64(i) / float64(ecd.m)
 
 		roots[i] = complex(math.Cos(angle), math.Sin(angle))
 	}
-	roots[encoder.m] = roots[0]
+	roots[ecd.m] = roots[0]
 
 	return &encoderComplex128{
-		encoder:     encoder,
+		encoder:     ecd,
 		roots:       roots,
-		values:      make([]complex128, encoder.m>>2),
-		valuesFloat: make([]float64, encoder.m>>1),
+		values:      make([]complex128, ecd.m>>2),
+		valuesFloat: make([]float64, ecd.m>>1),
 	}
 }
 
-func (encoder *encoderComplex128) EncodeNew(values interface{}, level int, scale float64, logSlots int) (plaintext *Plaintext) {
-	plaintext = NewPlaintext(encoder.params, level, scale)
-	encoder.Encode(values, plaintext, logSlots)
+func (ecd *encoderComplex128) EncodeNew(values interface{}, level int, scale float64, logSlots int) (plaintext *Plaintext) {
+	plaintext = NewPlaintext(ecd.params, level, scale)
+	ecd.Encode(values, plaintext, logSlots)
 	return
 }
 
-func (encoder *encoderComplex128) Encode(values interface{}, plaintext *Plaintext, logSlots int) {
-	encoder.embed(values, logSlots, plaintext.Scale, plaintext.Value)
-	encoder.switchToNTTDomain(logSlots, false, plaintext.Value)
+func (ecd *encoderComplex128) Encode(values interface{}, plaintext *Plaintext, logSlots int) {
+	ecd.embed(values, logSlots, plaintext.Scale, plaintext.Value)
+	ecd.switchToNTTDomain(logSlots, false, plaintext.Value)
 }
 
-func (encoder *encoderComplex128) switchToNTTDomain(logSlots int, montgomery bool, polyOut interface{}) {
+func (ecd *encoderComplex128) switchToNTTDomain(logSlots int, montgomery bool, polyOut interface{}) {
 	switch p := polyOut.(type) {
 	case rlwe.PolyQP:
-		encoder.nttandmontgomery(p.Q.Level(), logSlots, encoder.params.RingQ(), montgomery, p.Q)
-		encoder.nttandmontgomery(p.P.Level(), logSlots, encoder.params.RingP(), montgomery, p.P)
+		ecd.nttandmontgomery(p.Q.Level(), logSlots, ecd.params.RingQ(), montgomery, p.Q)
+		ecd.nttandmontgomery(p.P.Level(), logSlots, ecd.params.RingP(), montgomery, p.P)
 	case *ring.Poly:
-		encoder.nttandmontgomery(p.Level(), logSlots, encoder.params.RingQ(), montgomery, p)
+		ecd.nttandmontgomery(p.Level(), logSlots, ecd.params.RingQ(), montgomery, p)
 	default:
 		panic("invalid polyOut type")
 	}
 }
 
-func (encoder *encoderComplex128) nttandmontgomery(level int, logSlots int, ringQ *ring.Ring, montgomery bool, pol *ring.Poly) {
-	if logSlots == encoder.params.MaxLogSlots() {
+func (ecd *encoderComplex128) nttandmontgomery(level int, logSlots int, ringQ *ring.Ring, montgomery bool, pol *ring.Poly) {
+	if logSlots == ecd.params.MaxLogSlots() {
 		ringQ.NTTLvl(level, pol, pol)
 		if montgomery {
 			ringQ.MFormLvl(level, pol, pol)
@@ -255,7 +293,7 @@ func (encoder *encoderComplex128) nttandmontgomery(level int, logSlots int, ring
 
 		var n int
 		var NTT func(coeffsIn, coeffsOut []uint64, N int, nttPsi []uint64, Q, QInv uint64, bredParams []uint64)
-		switch encoder.params.RingType() {
+		switch ecd.params.RingType() {
 		case ring.Standard:
 			n = 2 << logSlots
 			NTT = ring.NTT
@@ -264,7 +302,7 @@ func (encoder *encoderComplex128) nttandmontgomery(level int, logSlots int, ring
 			NTT = ring.NTTConjugateInvariant
 		}
 
-		N := encoder.params.N()
+		N := ecd.params.N()
 		gap := N / n
 		for i := 0; i < level+1; i++ {
 
@@ -288,15 +326,15 @@ func (encoder *encoderComplex128) nttandmontgomery(level int, logSlots int, ring
 	}
 }
 
-func (encoder *encoderComplex128) EncodeSlotsNew(values interface{}, level int, scale float64, logSlots int) (plaintext *Plaintext) {
-	return encoder.EncodeNew(values, level, scale, logSlots)
+func (ecd *encoderComplex128) EncodeSlotsNew(values interface{}, level int, scale float64, logSlots int) (plaintext *Plaintext) {
+	return ecd.EncodeNew(values, level, scale, logSlots)
 }
 
-func (encoder *encoderComplex128) EncodeSlots(values interface{}, plaintext *Plaintext, logSlots int) {
-	encoder.Encode(values, plaintext, logSlots)
+func (ecd *encoderComplex128) EncodeSlots(values interface{}, plaintext *Plaintext, logSlots int) {
+	ecd.Encode(values, plaintext, logSlots)
 }
 
-func (encoder *encoderComplex128) embed(values interface{}, logSlots int, scale float64, polyOut interface{}) {
+func (ecd *encoderComplex128) embed(values interface{}, logSlots int, scale float64, polyOut interface{}) {
 
 	slots := 1 << logSlots
 
@@ -307,42 +345,42 @@ func (encoder *encoderComplex128) embed(values interface{}, logSlots int, scale 
 	case []complex128:
 
 		// Checks that the number of values is with the possible range
-		if len(values) > int(encoder.params.RingQ().NthRoot>>1) || len(values) > slots || slots > int(encoder.params.RingQ().NthRoot>>2) {
+		if len(values) > int(ecd.params.RingQ().NthRoot>>1) || len(values) > slots || slots > int(ecd.params.RingQ().NthRoot>>2) {
 			panic("cannot Encode: too many values/slots for the given ring degree")
 		}
 
-		switch encoder.params.RingType() {
+		switch ecd.params.RingType() {
 
 		case ring.Standard:
 
-			copy(encoder.values[:len(values)], values)
+			copy(ecd.values[:len(values)], values)
 
 			for i := len(values); i < slots; i++ {
-				encoder.values[i] = 0
+				ecd.values[i] = 0
 			}
 
-			invfft(encoder.values, slots, encoder.m, encoder.rotGroup, encoder.roots)
+			invfft(ecd.values, slots, ecd.m, ecd.rotGroup, ecd.roots)
 
 			for i, j := 0, slots; i < slots; i, j = i+1, j+1 {
-				encoder.valuesFloat[i] = real(encoder.values[i])
-				encoder.valuesFloat[j] = imag(encoder.values[i])
+				ecd.valuesFloat[i] = real(ecd.values[i])
+				ecd.valuesFloat[j] = imag(ecd.values[i])
 			}
 
 		case ring.ConjugateInvariant:
 
 			// Discards the imaginary part
 			for i := range values {
-				encoder.values[i] = complex(real(values[i]), 0)
+				ecd.values[i] = complex(real(values[i]), 0)
 			}
 
 			for i := len(values); i < slots; i++ {
-				encoder.values[i] = 0
+				ecd.values[i] = 0
 			}
 
-			invfft(encoder.values, slots, encoder.m, encoder.rotGroup, encoder.roots)
+			invfft(ecd.values, slots, ecd.m, ecd.rotGroup, ecd.roots)
 
 			for i := 0; i < slots; i++ {
-				encoder.valuesFloat[i] = real(encoder.values[i])
+				ecd.valuesFloat[i] = real(ecd.values[i])
 			}
 
 		// Else panics
@@ -353,27 +391,27 @@ func (encoder *encoderComplex128) embed(values interface{}, logSlots int, scale 
 	// If floats only
 	case []float64:
 
-		if len(values) > int(encoder.params.RingQ().NthRoot>>1) || len(values) > slots || slots > int(encoder.params.RingQ().NthRoot>>2) {
+		if len(values) > int(ecd.params.RingQ().NthRoot>>1) || len(values) > slots || slots > int(ecd.params.RingQ().NthRoot>>2) {
 			panic("cannot Encode: too many values/slots for the given ring degree")
 		}
 
 		for i := range values {
-			encoder.values[i] = complex(values[i], 0)
+			ecd.values[i] = complex(values[i], 0)
 		}
 
 		for i := len(values); i < slots; i++ {
-			encoder.values[i] = 0
+			ecd.values[i] = 0
 		}
 
-		invfft(encoder.values, slots, encoder.m, encoder.rotGroup, encoder.roots)
+		invfft(ecd.values, slots, ecd.m, ecd.rotGroup, ecd.roots)
 
 		for i := 0; i < slots; i++ {
-			encoder.valuesFloat[i] = real(encoder.values[i])
+			ecd.valuesFloat[i] = real(ecd.values[i])
 		}
 
-		if encoder.params.RingType() == ring.Standard {
+		if ecd.params.RingType() == ring.Standard {
 			for i, j := 0, slots; i < slots; i, j = i+1, j+1 {
-				encoder.valuesFloat[j] = imag(encoder.values[i])
+				ecd.valuesFloat[j] = imag(ecd.values[i])
 			}
 		}
 
@@ -381,84 +419,84 @@ func (encoder *encoderComplex128) embed(values interface{}, logSlots int, scale 
 		panic("values must be []complex128 or []float64")
 	}
 
-	switch encoder.params.RingType() {
+	switch ecd.params.RingType() {
 	case ring.Standard:
-		encoder.scaleUp(encoder.valuesFloat[:2*slots], scale, polyOut)
+		ecd.scaleUp(ecd.valuesFloat[:2*slots], scale, polyOut)
 	case ring.ConjugateInvariant:
-		encoder.scaleUp(encoder.valuesFloat[:slots], scale, polyOut)
+		ecd.scaleUp(ecd.valuesFloat[:slots], scale, polyOut)
 	default:
 		panic("invalid ring type")
 	}
 
 }
 
-func (encoder *encoderComplex128) scaleUp(values []float64, scale float64, polyOut interface{}) {
+func (ecd *encoderComplex128) scaleUp(values []float64, scale float64, polyOut interface{}) {
 	switch p := polyOut.(type) {
 	case rlwe.PolyQP:
 		levelQ := p.Q.Level()
 		levelP := p.P.Level()
-		ringQP := encoder.params.RingQP()
+		ringQP := ecd.params.RingQP()
 		scaleUpVecExact(values, scale, ringQP.RingQ.Modulus[:levelQ+1], p.Q.Coeffs)
 		scaleUpVecExact(values, scale, ringQP.RingP.Modulus[:levelP+1], p.P.Coeffs)
 	case *ring.Poly:
-		scaleUpVecExact(values, scale, encoder.params.RingQ().Modulus[:p.Level()+1], p.Coeffs)
+		scaleUpVecExact(values, scale, ecd.params.RingQ().Modulus[:p.Level()+1], p.Coeffs)
 	default:
 		panic("invalid polyOut type")
 	}
 }
 
-func (encoder *encoderComplex128) GetErrSTDSlotDomain(valuesWant, valuesHave []complex128, scale float64) (std float64) {
+func (ecd *encoderComplex128) GetErrSTDSlotDomain(valuesWant, valuesHave []complex128, scale float64) (std float64) {
 	var err complex128
 	for i := range valuesWant {
 		err = valuesWant[i] - valuesHave[i]
-		encoder.valuesFloat[2*i] = real(err)
-		encoder.valuesFloat[2*i+1] = imag(err)
+		ecd.valuesFloat[2*i] = real(err)
+		ecd.valuesFloat[2*i+1] = imag(err)
 	}
-	return StandardDeviation(encoder.valuesFloat[:len(valuesWant)*2], scale)
+	return StandardDeviation(ecd.valuesFloat[:len(valuesWant)*2], scale)
 }
 
-func (encoder *encoderComplex128) GetErrSTDCoeffDomain(valuesWant, valuesHave []complex128, scale float64) (std float64) {
+func (ecd *encoderComplex128) GetErrSTDCoeffDomain(valuesWant, valuesHave []complex128, scale float64) (std float64) {
 
 	for i := range valuesHave {
-		encoder.values[i] = (valuesWant[i] - valuesHave[i])
+		ecd.values[i] = (valuesWant[i] - valuesHave[i])
 	}
 
-	for i := len(valuesHave); i < len(encoder.values); i++ {
-		encoder.values[i] = complex(0, 0)
+	for i := len(valuesHave); i < len(ecd.values); i++ {
+		ecd.values[i] = complex(0, 0)
 	}
 
 	// Runs FFT^-1 with the smallest power of two length that is greater than the input size
-	invfft(encoder.values, 1<<bits.Len64(uint64(len(valuesHave)-1)), encoder.m, encoder.rotGroup, encoder.roots)
+	invfft(ecd.values, 1<<bits.Len64(uint64(len(valuesHave)-1)), ecd.m, ecd.rotGroup, ecd.roots)
 
 	for i := range valuesWant {
-		encoder.valuesFloat[2*i] = real(encoder.values[i])
-		encoder.valuesFloat[2*i+1] = imag(encoder.values[i])
+		ecd.valuesFloat[2*i] = real(ecd.values[i])
+		ecd.valuesFloat[2*i+1] = imag(ecd.values[i])
 	}
 
-	return StandardDeviation(encoder.valuesFloat[:len(valuesWant)*2], scale)
+	return StandardDeviation(ecd.valuesFloat[:len(valuesWant)*2], scale)
 
 }
 
 // DecodePublic decodes the Plaintext values to a slice of complex128 values of size at most N/2.
 // Adds a Gaussian error to the plaintext of variance sigma and bound floor(sqrt(2*pi)*sigma) before decoding
-func (encoder *encoderComplex128) DecodePublic(plaintext *Plaintext, logSlots int, bound float64) (res []complex128) {
-	return encoder.DecodeSlotsPublic(plaintext, logSlots, bound)
+func (ecd *encoderComplex128) DecodePublic(plaintext *Plaintext, logSlots int, bound float64) (res []complex128) {
+	return ecd.DecodeSlotsPublic(plaintext, logSlots, bound)
 }
 
 // Decode decodes the Plaintext values to a slice of complex128 values of size at most N/2.
-func (encoder *encoderComplex128) Decode(plaintext *Plaintext, logSlots int) (res []complex128) {
-	return encoder.DecodeSlotsPublic(plaintext, logSlots, 0)
+func (ecd *encoderComplex128) Decode(plaintext *Plaintext, logSlots int) (res []complex128) {
+	return ecd.DecodeSlotsPublic(plaintext, logSlots, 0)
 }
 
 // DecodeSlotsPublic decodes the Plaintext values to a slice of complex128 values of size at most N/2.
 // Adds a Gaussian error to the plaintext of variance sigma and bound floor(sqrt(2*pi)*sigma) before decoding
-func (encoder *encoderComplex128) DecodeSlotsPublic(plaintext *Plaintext, logSlots int, bound float64) (res []complex128) {
-	return encoder.decodePublic(plaintext, logSlots, bound)
+func (ecd *encoderComplex128) DecodeSlotsPublic(plaintext *Plaintext, logSlots int, bound float64) (res []complex128) {
+	return ecd.decodePublic(plaintext, logSlots, bound)
 }
 
 // DecodeSlots decodes the Plaintext values to a slice of complex128 values of size at most N/2.
-func (encoder *encoderComplex128) DecodeSlots(plaintext *Plaintext, logSlots int) (res []complex128) {
-	return encoder.decodePublic(plaintext, logSlots, 0)
+func (ecd *encoderComplex128) DecodeSlots(plaintext *Plaintext, logSlots int) (res []complex128) {
+	return ecd.decodePublic(plaintext, logSlots, 0)
 }
 
 func polyToComplexNoCRT(coeffs []uint64, values []complex128, scale float64, logSlots int, isreal bool, ringQ *ring.Ring) {
@@ -538,17 +576,17 @@ func polyToComplexCRT(poly *ring.Poly, bigintCoeffs []*big.Int, values []complex
 	}
 }
 
-func (encoder *encoderComplex128) plaintextToComplex(level int, scale float64, logSlots int, p *ring.Poly, values []complex128) {
+func (ecd *encoderComplex128) plaintextToComplex(level int, scale float64, logSlots int, p *ring.Poly, values []complex128) {
 
-	isreal := encoder.params.RingType() == ring.ConjugateInvariant
+	isreal := ecd.params.RingType() == ring.ConjugateInvariant
 	if level == 0 {
-		polyToComplexNoCRT(p.Coeffs[0], values, scale, logSlots, isreal, encoder.params.RingQ())
+		polyToComplexNoCRT(p.Coeffs[0], values, scale, logSlots, isreal, ecd.params.RingQ())
 	} else {
-		polyToComplexCRT(p, encoder.bigintCoeffs, values, scale, logSlots, isreal, encoder.params.RingQ(), encoder.bigintChain[level])
+		polyToComplexCRT(p, ecd.bigintCoeffs, values, scale, logSlots, isreal, ecd.params.RingQ(), ecd.bigintChain[level])
 	}
 
 	if isreal { // [X]/(X^N+1) to [X+X^-1]/(X^N+1)
-		tmp := encoder.values
+		tmp := ecd.values
 		slots := 1 << logSlots
 		for i := 1; i < slots; i++ {
 			tmp[i] -= complex(0, real(tmp[slots-i]))
@@ -556,37 +594,37 @@ func (encoder *encoderComplex128) plaintextToComplex(level int, scale float64, l
 	}
 }
 
-func (encoder *encoderComplex128) decodePublic(plaintext *Plaintext, logSlots int, sigma float64) (res []complex128) {
+func (ecd *encoderComplex128) decodePublic(plaintext *Plaintext, logSlots int, sigma float64) (res []complex128) {
 
 	slots := 1 << logSlots
 
-	if slots > int(encoder.params.RingQ().NthRoot>>2) {
+	if slots > int(ecd.params.RingQ().NthRoot>>2) {
 		panic("cannot Decode: too many slots for the given ring degree")
 	}
 
 	if plaintext.Value.IsNTT {
-		encoder.params.RingQ().InvNTTLvl(plaintext.Level(), plaintext.Value, encoder.polypool)
+		ecd.params.RingQ().InvNTTLvl(plaintext.Level(), plaintext.Value, ecd.polypool)
 	} else {
-		ring.CopyValuesLvl(plaintext.Level(), plaintext.Value, encoder.polypool)
+		ring.CopyValuesLvl(plaintext.Level(), plaintext.Value, ecd.polypool)
 	}
 
 	// B = floor(sigma * sqrt(2*pi))
 	if sigma != 0 {
-		encoder.gaussianSampler.ReadAndAddFromDistLvl(plaintext.Level(), encoder.polypool, encoder.params.RingQ(), sigma, int(2.5066282746310002*sigma))
+		ecd.gaussianSampler.ReadAndAddFromDistLvl(plaintext.Level(), ecd.polypool, ecd.params.RingQ(), sigma, int(2.5066282746310002*sigma))
 	}
 
-	encoder.plaintextToComplex(plaintext.Level(), plaintext.Scale, logSlots, encoder.polypool, encoder.values)
+	ecd.plaintextToComplex(plaintext.Level(), plaintext.Scale, logSlots, ecd.polypool, ecd.values)
 
-	fft(encoder.values, slots, encoder.m, encoder.rotGroup, encoder.roots)
+	fft(ecd.values, slots, ecd.m, ecd.rotGroup, ecd.roots)
 
 	res = make([]complex128, slots)
 
 	for i := range res {
-		res[i] = encoder.values[i]
+		res[i] = ecd.values[i]
 	}
 
-	for i := range encoder.values {
-		encoder.values[i] = 0
+	for i := range ecd.values {
+		ecd.values[i] = 0
 	}
 
 	return
@@ -647,77 +685,77 @@ func fft(values []complex128, N, M int, rotGroup []int, roots []complex128) {
 
 // EncodeCoeffs takes as input a polynomial a0 + a1x + a2x^2 + ... + an-1x^n-1 with float coefficient
 // and returns a scaled integer plaintext polynomial. Encodes at the input plaintext level.
-func (encoder *encoderComplex128) EncodeCoeffs(values []float64, plaintext *Plaintext) {
+func (ecd *encoderComplex128) EncodeCoeffs(values []float64, plaintext *Plaintext) {
 
-	if len(values) > encoder.params.N() {
+	if len(values) > ecd.params.N() {
 		panic("cannot EncodeCoeffs : too many values (maximum is N)")
 	}
-	scaleUpVecExact(values, plaintext.Scale, encoder.params.RingQ().Modulus[:plaintext.Level()+1], plaintext.Value.Coeffs)
-	encoder.params.RingQ().NTTLvl(plaintext.Level(), plaintext.Value, plaintext.Value)
+	scaleUpVecExact(values, plaintext.Scale, ecd.params.RingQ().Modulus[:plaintext.Level()+1], plaintext.Value.Coeffs)
+	ecd.params.RingQ().NTTLvl(plaintext.Level(), plaintext.Value, plaintext.Value)
 	plaintext.Value.IsNTT = true
 }
 
-func (encoder *encoderComplex128) EncodeCoeffsNew(values []float64, level int, scale float64) (plaintext *Plaintext) {
-	plaintext = NewPlaintext(encoder.params, level, scale)
-	encoder.EncodeCoeffs(values, plaintext)
+func (ecd *encoderComplex128) EncodeCoeffsNew(values []float64, level int, scale float64) (plaintext *Plaintext) {
+	plaintext = NewPlaintext(ecd.params, level, scale)
+	ecd.EncodeCoeffs(values, plaintext)
 	return
 }
 
 // DecodeCoeffsPublic takes as input a plaintext and returns the scaled down coefficient of the plaintext in float64.
 // Rounds the decimal part of the output (the bits under the scale) to "logPrecision" bits of precision.
-func (encoder *encoderComplex128) DecodeCoeffsPublic(plaintext *Plaintext, sigma float64) (res []float64) {
-	return encoder.decodeCoeffsPublic(plaintext, sigma)
+func (ecd *encoderComplex128) DecodeCoeffsPublic(plaintext *Plaintext, sigma float64) (res []float64) {
+	return ecd.decodeCoeffsPublic(plaintext, sigma)
 }
 
-func (encoder *encoderComplex128) DecodeCoeffs(plaintext *Plaintext) (res []float64) {
-	return encoder.decodeCoeffsPublic(plaintext, 0)
+func (ecd *encoderComplex128) DecodeCoeffs(plaintext *Plaintext) (res []float64) {
+	return ecd.decodeCoeffsPublic(plaintext, 0)
 }
 
 // DecodeCoeffs takes as input a plaintext and returns the scaled down coefficient of the plaintext in float64.
-func (encoder *encoderComplex128) decodeCoeffsPublic(plaintext *Plaintext, sigma float64) (res []float64) {
+func (ecd *encoderComplex128) decodeCoeffsPublic(plaintext *Plaintext, sigma float64) (res []float64) {
 
 	if plaintext.Value.IsNTT {
-		encoder.params.RingQ().InvNTTLvl(plaintext.Level(), plaintext.Value, encoder.polypool)
+		ecd.params.RingQ().InvNTTLvl(plaintext.Level(), plaintext.Value, ecd.polypool)
 	} else {
-		ring.CopyValuesLvl(plaintext.Level(), plaintext.Value, encoder.polypool)
+		ring.CopyValuesLvl(plaintext.Level(), plaintext.Value, ecd.polypool)
 	}
 
 	if sigma != 0 {
 		// B = floor(sigma * sqrt(2*pi))
-		encoder.gaussianSampler.ReadAndAddFromDistLvl(plaintext.Level(), encoder.polypool, encoder.params.RingQ(), sigma, int(2.5066282746310002*sigma))
+		ecd.gaussianSampler.ReadAndAddFromDistLvl(plaintext.Level(), ecd.polypool, ecd.params.RingQ(), sigma, int(2.5066282746310002*sigma))
 	}
 
-	res = make([]float64, encoder.params.N())
+	res = make([]float64, ecd.params.N())
 
 	// We have more than one moduli and need the CRT reconstruction
 	if plaintext.Level() > 0 {
 
-		encoder.params.RingQ().PolyToBigint(encoder.polypool, encoder.bigintCoeffs)
+		ecd.params.RingQ().PolyToBigint(ecd.polypool, ecd.bigintCoeffs)
 
-		Q := encoder.bigintChain[plaintext.Level()]
+		Q := ecd.bigintChain[plaintext.Level()]
 
-		encoder.qHalf.Set(Q)
-		encoder.qHalf.Rsh(encoder.qHalf, 1)
+		ecd.qHalf.Set(Q)
+		ecd.qHalf.Rsh(ecd.qHalf, 1)
 
 		var sign int
 
 		for i := range res {
 
 			// Centers the value around the current modulus
-			encoder.bigintCoeffs[i].Mod(encoder.bigintCoeffs[i], Q)
+			ecd.bigintCoeffs[i].Mod(ecd.bigintCoeffs[i], Q)
 
-			sign = encoder.bigintCoeffs[i].Cmp(encoder.qHalf)
+			sign = ecd.bigintCoeffs[i].Cmp(ecd.qHalf)
 			if sign == 1 || sign == 0 {
-				encoder.bigintCoeffs[i].Sub(encoder.bigintCoeffs[i], Q)
+				ecd.bigintCoeffs[i].Sub(ecd.bigintCoeffs[i], Q)
 			}
 
-			res[i] = scaleDown(encoder.bigintCoeffs[i], plaintext.Scale)
+			res[i] = scaleDown(ecd.bigintCoeffs[i], plaintext.Scale)
 		}
 		// We can directly get the coefficients
 	} else {
 
-		Q := encoder.params.RingQ().Modulus[0]
-		coeffs := encoder.polypool.Coeffs[0]
+		Q := ecd.params.RingQ().Modulus[0]
+		coeffs := ecd.polypool.Coeffs[0]
 
 		for i := range res {
 
@@ -736,18 +774,40 @@ func (encoder *encoderComplex128) decodeCoeffsPublic(plaintext *Plaintext, sigma
 
 type encoderBigComplex struct {
 	encoder
-	zero            *big.Float
-	cMul            *ring.ComplexMultiplier
-	logPrecision    int
-	values          []*ring.Complex
-	valuesfloat     []*big.Float
-	roots           []*ring.Complex
-	gaussianSampler *ring.GaussianSampler
+	zero         *big.Float
+	cMul         *ring.ComplexMultiplier
+	logPrecision int
+	values       []*ring.Complex
+	valuesfloat  []*big.Float
+	roots        []*ring.Complex
+}
+
+func (ecd *encoderBigComplex) ShallowCopy() EncoderBigComplex {
+
+	values := make([]*ring.Complex, ecd.m>>2)
+	valuesfloat := make([]*big.Float, ecd.m>>1)
+
+	for i := 0; i < ecd.m>>2; i++ {
+
+		values[i] = ring.NewComplex(ring.NewFloat(0, ecd.logPrecision), ring.NewFloat(0, ecd.logPrecision))
+		valuesfloat[i*2] = ring.NewFloat(0, ecd.logPrecision)
+		valuesfloat[(i*2)+1] = ring.NewFloat(0, ecd.logPrecision)
+	}
+
+	return &encoderBigComplex{
+		encoder:      *ecd.encoder.ShallowCopy(),
+		zero:         ring.NewFloat(0, ecd.logPrecision),
+		cMul:         ring.NewComplexMultiplier(),
+		logPrecision: ecd.logPrecision,
+		values:       values,
+		valuesfloat:  valuesfloat,
+		roots:        ecd.roots,
+	}
 }
 
 // NewEncoderBigComplex creates a new encoder using arbitrary precision complex arithmetic.
 func NewEncoderBigComplex(params Parameters, logPrecision int) EncoderBigComplex {
-	encoder := newEncoder(params)
+	ecd := newEncoder(params)
 
 	var PI = new(big.Float)
 	PI.SetPrec(uint(logPrecision))
@@ -759,12 +819,12 @@ func NewEncoderBigComplex(params Parameters, logPrecision int) EncoderBigComplex
 	PIHalf.Quo(PIHalf, ring.NewFloat(2, logPrecision))
 
 	var angle *big.Float
-	roots := make([]*ring.Complex, encoder.m+1)
-	for i := 0; i < encoder.m; i++ {
+	roots := make([]*ring.Complex, ecd.m+1)
+	for i := 0; i < ecd.m; i++ {
 		angle = ring.NewFloat(2, logPrecision)
 		angle.Mul(angle, PI)
 		angle.Mul(angle, ring.NewFloat(float64(i), logPrecision))
-		angle.Quo(angle, ring.NewFloat(float64(encoder.m), logPrecision))
+		angle.Quo(angle, ring.NewFloat(float64(ecd.m), logPrecision))
 
 		real := ring.Cos(angle)
 		angle.Sub(PIHalf, angle)
@@ -773,12 +833,12 @@ func NewEncoderBigComplex(params Parameters, logPrecision int) EncoderBigComplex
 		roots[i] = ring.NewComplex(real, imag)
 	}
 
-	roots[encoder.m] = roots[0].Copy()
+	roots[ecd.m] = roots[0].Copy()
 
-	values := make([]*ring.Complex, encoder.m>>2)
-	valuesfloat := make([]*big.Float, encoder.m>>1)
+	values := make([]*ring.Complex, ecd.m>>2)
+	valuesfloat := make([]*big.Float, ecd.m>>1)
 
-	for i := 0; i < encoder.m>>2; i++ {
+	for i := 0; i < ecd.m>>2; i++ {
 
 		values[i] = ring.NewComplex(ring.NewFloat(0, logPrecision), ring.NewFloat(0, logPrecision))
 		valuesfloat[i*2] = ring.NewFloat(0, logPrecision)
@@ -786,7 +846,7 @@ func NewEncoderBigComplex(params Parameters, logPrecision int) EncoderBigComplex
 	}
 
 	return &encoderBigComplex{
-		encoder:      encoder,
+		encoder:      ecd,
 		zero:         ring.NewFloat(0, logPrecision),
 		cMul:         ring.NewComplexMultiplier(),
 		logPrecision: logPrecision,
@@ -796,17 +856,17 @@ func NewEncoderBigComplex(params Parameters, logPrecision int) EncoderBigComplex
 	}
 }
 
-func (encoder *encoderBigComplex) EncodeNew(values []*ring.Complex, level int, scale float64, logSlots int) (plaintext *Plaintext) {
-	plaintext = NewPlaintext(encoder.params, level, scale)
-	encoder.Encode(values, plaintext, logSlots)
+func (ecd *encoderBigComplex) EncodeNew(values []*ring.Complex, level int, scale float64, logSlots int) (plaintext *Plaintext) {
+	plaintext = NewPlaintext(ecd.params, level, scale)
+	ecd.Encode(values, plaintext, logSlots)
 	return
 }
 
-func (encoder *encoderBigComplex) Encode(values []*ring.Complex, plaintext *Plaintext, logSlots int) {
+func (ecd *encoderBigComplex) Encode(values []*ring.Complex, plaintext *Plaintext, logSlots int) {
 
 	slots := 1 << logSlots
 
-	if len(values) > encoder.params.N()/2 || len(values) > slots || logSlots > encoder.params.LogN()-1 {
+	if len(values) > ecd.params.N()/2 || len(values) > slots || logSlots > ecd.params.LogN()-1 {
 		panic("cannot Encode: too many values/slots for the given ring degree")
 	}
 
@@ -815,70 +875,70 @@ func (encoder *encoderBigComplex) Encode(values []*ring.Complex, plaintext *Plai
 	}
 
 	for i := 0; i < slots; i++ {
-		encoder.values[i].Set(values[i])
+		ecd.values[i].Set(values[i])
 	}
 
-	encoder.InvFFT(encoder.values, slots)
+	ecd.InvFFT(ecd.values, slots)
 
-	gap := (encoder.params.RingQ().N >> 1) / slots
+	gap := (ecd.params.RingQ().N >> 1) / slots
 
-	for i, jdx, idx := 0, (encoder.params.RingQ().N >> 1), 0; i < slots; i, jdx, idx = i+1, jdx+gap, idx+gap {
-		encoder.valuesfloat[idx].Set(encoder.values[i].Real())
-		encoder.valuesfloat[jdx].Set(encoder.values[i].Imag())
+	for i, jdx, idx := 0, (ecd.params.RingQ().N >> 1), 0; i < slots; i, jdx, idx = i+1, jdx+gap, idx+gap {
+		ecd.valuesfloat[idx].Set(ecd.values[i].Real())
+		ecd.valuesfloat[jdx].Set(ecd.values[i].Imag())
 	}
 
-	scaleUpVecExactBigFloat(encoder.valuesfloat, plaintext.Scale, encoder.params.RingQ().Modulus[:plaintext.Level()+1], plaintext.Value.Coeffs)
+	scaleUpVecExactBigFloat(ecd.valuesfloat, plaintext.Scale, ecd.params.RingQ().Modulus[:plaintext.Level()+1], plaintext.Value.Coeffs)
 
-	coeffsBigInt := make([]*big.Int, encoder.params.N())
+	coeffsBigInt := make([]*big.Int, ecd.params.N())
 
-	encoder.params.RingQ().PolyToBigint(plaintext.Value, coeffsBigInt)
+	ecd.params.RingQ().PolyToBigint(plaintext.Value, coeffsBigInt)
 
-	for i := 0; i < (encoder.params.RingQ().N >> 1); i++ {
-		encoder.values[i].Real().Set(encoder.zero)
-		encoder.values[i].Imag().Set(encoder.zero)
+	for i := 0; i < (ecd.params.RingQ().N >> 1); i++ {
+		ecd.values[i].Real().Set(ecd.zero)
+		ecd.values[i].Imag().Set(ecd.zero)
 	}
 
-	for i := 0; i < encoder.params.RingQ().N; i++ {
-		encoder.valuesfloat[i].Set(encoder.zero)
+	for i := 0; i < ecd.params.RingQ().N; i++ {
+		ecd.valuesfloat[i].Set(ecd.zero)
 	}
 
-	encoder.params.RingQ().NTTLvl(plaintext.Level(), plaintext.Value, plaintext.Value)
+	ecd.params.RingQ().NTTLvl(plaintext.Level(), plaintext.Value, plaintext.Value)
 	plaintext.Value.IsNTT = true
 }
 
-func (encoder *encoderBigComplex) DecodePublic(plaintext *Plaintext, logSlots int, sigma float64) (res []*ring.Complex) {
-	return encoder.decodePublic(plaintext, logSlots, sigma)
+func (ecd *encoderBigComplex) DecodePublic(plaintext *Plaintext, logSlots int, sigma float64) (res []*ring.Complex) {
+	return ecd.decodePublic(plaintext, logSlots, sigma)
 }
 
-func (encoder *encoderBigComplex) Decode(plaintext *Plaintext, logSlots int) (res []*ring.Complex) {
-	return encoder.decodePublic(plaintext, logSlots, 0)
+func (ecd *encoderBigComplex) Decode(plaintext *Plaintext, logSlots int) (res []*ring.Complex) {
+	return ecd.decodePublic(plaintext, logSlots, 0)
 }
 
-func (encoder *encoderBigComplex) decodePublic(plaintext *Plaintext, logSlots int, sigma float64) (res []*ring.Complex) {
+func (ecd *encoderBigComplex) decodePublic(plaintext *Plaintext, logSlots int, sigma float64) (res []*ring.Complex) {
 
 	slots := 1 << logSlots
 
-	if logSlots > encoder.params.LogN()-1 {
+	if logSlots > ecd.params.LogN()-1 {
 		panic("cannot Decode: too many slots for the given ring degree")
 	}
 
-	encoder.params.RingQ().InvNTTLvl(plaintext.Level(), plaintext.Value, encoder.polypool)
+	ecd.params.RingQ().InvNTTLvl(plaintext.Level(), plaintext.Value, ecd.polypool)
 
 	if sigma != 0 {
 		// B = floor(sigma * sqrt(2*pi))
-		encoder.gaussianSampler.ReadAndAddFromDistLvl(plaintext.Level(), encoder.polypool, encoder.params.RingQ(), sigma, int(2.5066282746310002*sigma+0.5))
+		ecd.gaussianSampler.ReadAndAddFromDistLvl(plaintext.Level(), ecd.polypool, ecd.params.RingQ(), sigma, int(2.5066282746310002*sigma+0.5))
 	}
 
-	encoder.params.RingQ().PolyToBigint(encoder.polypool, encoder.bigintCoeffs)
+	ecd.params.RingQ().PolyToBigint(ecd.polypool, ecd.bigintCoeffs)
 
-	Q := encoder.bigintChain[plaintext.Level()]
+	Q := ecd.bigintChain[plaintext.Level()]
 
-	maxSlots := encoder.params.RingQ().N >> 1
+	maxSlots := ecd.params.RingQ().N >> 1
 
-	scaleFlo := ring.NewFloat(plaintext.Scale, encoder.logPrecision)
+	scaleFlo := ring.NewFloat(plaintext.Scale, ecd.logPrecision)
 
-	encoder.qHalf.Set(Q)
-	encoder.qHalf.Rsh(encoder.qHalf, 1)
+	ecd.qHalf.Set(Q)
+	ecd.qHalf.Rsh(ecd.qHalf, 1)
 
 	gap := maxSlots / slots
 
@@ -887,43 +947,43 @@ func (encoder *encoderBigComplex) decodePublic(plaintext *Plaintext, logSlots in
 	for i, idx := 0, 0; i < slots; i, idx = i+1, idx+gap {
 
 		// Centers the value around the current modulus
-		encoder.bigintCoeffs[idx].Mod(encoder.bigintCoeffs[idx], Q)
-		sign = encoder.bigintCoeffs[idx].Cmp(encoder.qHalf)
+		ecd.bigintCoeffs[idx].Mod(ecd.bigintCoeffs[idx], Q)
+		sign = ecd.bigintCoeffs[idx].Cmp(ecd.qHalf)
 		if sign == 1 || sign == 0 {
-			encoder.bigintCoeffs[idx].Sub(encoder.bigintCoeffs[idx], Q)
+			ecd.bigintCoeffs[idx].Sub(ecd.bigintCoeffs[idx], Q)
 		}
 
 		// Centers the value around the current modulus
-		encoder.bigintCoeffs[idx+maxSlots].Mod(encoder.bigintCoeffs[idx+maxSlots], Q)
-		sign = encoder.bigintCoeffs[idx+maxSlots].Cmp(encoder.qHalf)
+		ecd.bigintCoeffs[idx+maxSlots].Mod(ecd.bigintCoeffs[idx+maxSlots], Q)
+		sign = ecd.bigintCoeffs[idx+maxSlots].Cmp(ecd.qHalf)
 		if sign == 1 || sign == 0 {
-			encoder.bigintCoeffs[idx+maxSlots].Sub(encoder.bigintCoeffs[idx+maxSlots], Q)
+			ecd.bigintCoeffs[idx+maxSlots].Sub(ecd.bigintCoeffs[idx+maxSlots], Q)
 		}
 
-		encoder.values[i].Real().SetInt(encoder.bigintCoeffs[idx])
-		encoder.values[i].Real().Quo(encoder.values[i].Real(), scaleFlo)
+		ecd.values[i].Real().SetInt(ecd.bigintCoeffs[idx])
+		ecd.values[i].Real().Quo(ecd.values[i].Real(), scaleFlo)
 
-		encoder.values[i].Imag().SetInt(encoder.bigintCoeffs[idx+maxSlots])
-		encoder.values[i].Imag().Quo(encoder.values[i].Imag(), scaleFlo)
+		ecd.values[i].Imag().SetInt(ecd.bigintCoeffs[idx+maxSlots])
+		ecd.values[i].Imag().Quo(ecd.values[i].Imag(), scaleFlo)
 	}
 
-	encoder.FFT(encoder.values, slots)
+	ecd.FFT(ecd.values, slots)
 
 	res = make([]*ring.Complex, slots)
 
 	for i := range res {
-		res[i] = encoder.values[i].Copy()
+		res[i] = ecd.values[i].Copy()
 	}
 
 	for i := 0; i < maxSlots; i++ {
-		encoder.values[i].Real().Set(encoder.zero)
-		encoder.values[i].Imag().Set(encoder.zero)
+		ecd.values[i].Real().Set(ecd.zero)
+		ecd.values[i].Imag().Set(ecd.zero)
 	}
 
 	return
 }
 
-func (encoder *encoderBigComplex) InvFFT(values []*ring.Complex, N int) {
+func (ecd *encoderBigComplex) InvFFT(values []*ring.Complex, N int) {
 
 	var lenh, lenq, gap, idx int
 	u := ring.NewComplex(nil, nil)
@@ -933,19 +993,19 @@ func (encoder *encoderBigComplex) InvFFT(values []*ring.Complex, N int) {
 		for i := 0; i < N; i += len {
 			lenh = len >> 1
 			lenq = len << 2
-			gap = encoder.m / lenq
+			gap = ecd.m / lenq
 			for j := 0; j < lenh; j++ {
-				idx = (lenq - (encoder.rotGroup[j] % lenq)) * gap
+				idx = (lenq - (ecd.rotGroup[j] % lenq)) * gap
 				u.Add(values[i+j], values[i+j+lenh])
 				v.Sub(values[i+j], values[i+j+lenh])
-				encoder.cMul.Mul(v, encoder.roots[idx], v)
+				ecd.cMul.Mul(v, ecd.roots[idx], v)
 				values[i+j].Set(u)
 				values[i+j+lenh].Set(v)
 			}
 		}
 	}
 
-	NBig := ring.NewFloat(float64(N), encoder.logPrecision)
+	NBig := ring.NewFloat(float64(N), ecd.logPrecision)
 	for i := range values {
 		values[i][0].Quo(values[i][0], NBig)
 		values[i][1].Quo(values[i][1], NBig)
@@ -954,7 +1014,7 @@ func (encoder *encoderBigComplex) InvFFT(values []*ring.Complex, N int) {
 	SliceBitReverseInPlaceRingComplex(values, N)
 }
 
-func (encoder *encoderBigComplex) FFT(values []*ring.Complex, N int) {
+func (ecd *encoderBigComplex) FFT(values []*ring.Complex, N int) {
 
 	var lenh, lenq, gap, idx int
 
@@ -967,12 +1027,12 @@ func (encoder *encoderBigComplex) FFT(values []*ring.Complex, N int) {
 		for i := 0; i < N; i += len {
 			lenh = len >> 1
 			lenq = len << 2
-			gap = encoder.m / lenq
+			gap = ecd.m / lenq
 			for j := 0; j < lenh; j++ {
-				idx = (encoder.rotGroup[j] % lenq) * gap
+				idx = (ecd.rotGroup[j] % lenq) * gap
 				u.Set(values[i+j])
 				v.Set(values[i+j+lenh])
-				encoder.cMul.Mul(v, encoder.roots[idx], v)
+				ecd.cMul.Mul(v, ecd.roots[idx], v)
 				values[i+j].Add(u, v)
 				values[i+j+lenh].Sub(u, v)
 			}

--- a/ckks/encoder.go
+++ b/ckks/encoder.go
@@ -131,34 +131,6 @@ type Encoder interface {
 	ShallowCopy() Encoder
 }
 
-// EncoderBigComplex is an interface that implements the encoding algorithms with arbitrary precision.
-type EncoderBigComplex interface {
-
-	// Encode encodes a set of values on the target plaintext.
-	// Encoding is done at the level and scale of the plaintext.
-	// User must ensure that 1 <= len(values) <= 2^logSlots < 2^LogN.
-	Encode(values []*ring.Complex, plaintext *Plaintext, logSlots int)
-
-	// EncodeNew encodes a set of values on a new plaintext.
-	// Encoding is done at the provided level and with the provided scale.
-	// User must ensure that 1 <= len(values) <= 2^logSlots < 2^LogN.
-	EncodeNew(values []*ring.Complex, level int, scale float64, logSlots int) (plaintext *Plaintext)
-
-	// Decode decodes the input plaintext on a new slice of ring.Complex.
-	Decode(plaintext *Plaintext, logSlots int) (res []*ring.Complex)
-
-	// FFT evaluates the decoding matrix on a slice of ring.Complex values.
-	FFT(values []*ring.Complex, N int)
-
-	// InvFFT evaluates the encoding matrix on a slice of ring.Complex values.
-	InvFFT(values []*ring.Complex, N int)
-
-	// ShallowCopy creates a shallow copy of this EncoderBigComplex in which all the read-only data-structures are
-	// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
-	// EncoderBigComplex can be used concurrently.
-	ShallowCopy() EncoderBigComplex
-}
-
 // encoder is a struct storing the necessary parameters to encode a slice of complex number on a Plaintext.
 type encoder struct {
 	params       Parameters
@@ -179,6 +151,9 @@ type encoderComplex128 struct {
 	roots       []complex128
 }
 
+// ShallowCopy creates a shallow copy of EncoderBigComplex in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// EncoderBigComplex can be used concurrently.
 func (ecd *encoder) ShallowCopy() *encoder {
 
 	prng, err := utils.NewPRNG()
@@ -772,6 +747,34 @@ func (ecd *encoderComplex128) decodeCoeffsPublic(plaintext *Plaintext, sigma flo
 	return
 }
 
+// EncoderBigComplex is an interface that implements the encoding algorithms with arbitrary precision.
+type EncoderBigComplex interface {
+
+	// Encode encodes a set of values on the target plaintext.
+	// Encoding is done at the level and scale of the plaintext.
+	// User must ensure that 1 <= len(values) <= 2^logSlots < 2^LogN.
+	Encode(values []*ring.Complex, plaintext *Plaintext, logSlots int)
+
+	// EncodeNew encodes a set of values on a new plaintext.
+	// Encoding is done at the provided level and with the provided scale.
+	// User must ensure that 1 <= len(values) <= 2^logSlots < 2^LogN.
+	EncodeNew(values []*ring.Complex, level int, scale float64, logSlots int) (plaintext *Plaintext)
+
+	// Decode decodes the input plaintext on a new slice of ring.Complex.
+	Decode(plaintext *Plaintext, logSlots int) (res []*ring.Complex)
+
+	// FFT evaluates the decoding matrix on a slice of ring.Complex values.
+	FFT(values []*ring.Complex, N int)
+
+	// InvFFT evaluates the encoding matrix on a slice of ring.Complex values.
+	InvFFT(values []*ring.Complex, N int)
+
+	// ShallowCopy creates a shallow copy of this EncoderBigComplex in which all the read-only data-structures are
+	// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+	// EncoderBigComplex can be used concurrently.
+	ShallowCopy() EncoderBigComplex
+}
+
 type encoderBigComplex struct {
 	encoder
 	zero         *big.Float
@@ -782,6 +785,9 @@ type encoderBigComplex struct {
 	roots        []*ring.Complex
 }
 
+// ShallowCopy creates a shallow copy of EncoderBigComplex in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// EncoderBigComplex can be used concurrently.
 func (ecd *encoderBigComplex) ShallowCopy() EncoderBigComplex {
 
 	values := make([]*ring.Complex, ecd.m>>2)

--- a/ckks/encryptor.go
+++ b/ckks/encryptor.go
@@ -11,6 +11,10 @@ type Encryptor interface {
 	EncryptNew(plaintext *Plaintext) *Ciphertext
 	EncryptFromCRP(plaintext *Plaintext, crp *ring.Poly, ciphertext *Ciphertext)
 	EncryptFromCRPNew(plaintext *Plaintext, crp *ring.Poly) *Ciphertext
+
+	ShallowCopy() Encryptor
+	WithKey(key interface{}) Encryptor
+	SetKey(key interface{}) Encryptor
 }
 
 type encryptor struct {
@@ -58,4 +62,22 @@ func (enc *encryptor) EncryptFromCRPNew(plaintext *Plaintext, crp *ring.Poly) (c
 	ciphertext = NewCiphertext(enc.params, 1, plaintext.Level(), plaintext.Scale)
 	enc.Encryptor.EncryptFromCRP(plaintext.Plaintext, crp, ciphertext.Ciphertext)
 	return
+}
+
+// ShallowCopy creates a shallow copy of this encryptor in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Encryptors can be used concurrently.
+func (enc *encryptor) ShallowCopy() Encryptor {
+	return &encryptor{enc.Encryptor.ShallowCopy(), enc.params}
+}
+
+// WithKey creates a shallow copy of the receiver Encryptor with the provided key.
+// This is equivalent to calling Encryptor.ShallowCopy().WithKey(*)
+func (enc *encryptor) WithKey(key interface{}) Encryptor {
+	return &encryptor{enc.Encryptor.WithKey(key), enc.params}
+}
+
+// SetKey sets the key of the target encryptor. Either secret-key, public-key or nil can be passed as argument.
+func (enc *encryptor) SetKey(key interface{}) Encryptor {
+	return &encryptor{enc.Encryptor.SetKey(key), enc.params}
 }

--- a/ckks/encryptor.go
+++ b/ckks/encryptor.go
@@ -14,7 +14,6 @@ type Encryptor interface {
 
 	ShallowCopy() Encryptor
 	WithKey(key interface{}) Encryptor
-	SetKey(key interface{}) Encryptor
 }
 
 type encryptor struct {
@@ -75,9 +74,4 @@ func (enc *encryptor) ShallowCopy() Encryptor {
 // This is equivalent to calling Encryptor.ShallowCopy().WithKey(*)
 func (enc *encryptor) WithKey(key interface{}) Encryptor {
 	return &encryptor{enc.Encryptor.WithKey(key), enc.params}
-}
-
-// SetKey sets the key of the target encryptor. Either secret-key, public-key or nil can be passed as argument.
-func (enc *encryptor) SetKey(key interface{}) Encryptor {
-	return &encryptor{enc.Encryptor.SetKey(key), enc.params}
 }

--- a/ckks/encryptor.go
+++ b/ckks/encryptor.go
@@ -69,7 +69,7 @@ func (enc *encryptor) ShallowCopy() Encryptor {
 	return &encryptor{enc.Encryptor.ShallowCopy(), enc.params}
 }
 
-// ShallowCopy creates a shallow copy of this encryptor with a new key in which all the read-only data-structures are
+// WithKey creates a shallow copy of this encryptor with a new key in which all the read-only data-structures are
 // shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
 // Encryptors can be used concurrently.
 // Key can be *rlwe.PublicKey or *rlwe.SecretKey.

--- a/ckks/encryptor.go
+++ b/ckks/encryptor.go
@@ -24,13 +24,6 @@ func NewEncryptor(params Parameters, key interface{}) Encryptor {
 	return &encryptor{rlwe.NewEncryptor(params.Parameters, key), params}
 }
 
-// NewFastEncryptor instantiates a new Encryptor for the CKKS scheme.
-// This encryptor's Encrypt method first encrypts zero in Q and then adds the plaintext.
-// This method is faster than the normal encryptor but result in a noisier ciphertext.
-func NewFastEncryptor(params Parameters, key *rlwe.PublicKey) Encryptor {
-	return &encryptor{rlwe.NewFastEncryptor(params.Parameters, key), params}
-}
-
 // Encrypt encrypts the input plaintext and write the result on ciphertext. The encryption
 // algorithm depends on how the receiver encryptor was initialized (see NewEncryptor
 // and NewFastEncryptor).

--- a/ckks/encryptor.go
+++ b/ckks/encryptor.go
@@ -11,7 +11,6 @@ type Encryptor interface {
 	EncryptNew(plaintext *Plaintext) *Ciphertext
 	EncryptFromCRP(plaintext *Plaintext, crp *ring.Poly, ciphertext *Ciphertext)
 	EncryptFromCRPNew(plaintext *Plaintext, crp *ring.Poly) *Ciphertext
-
 	ShallowCopy() Encryptor
 	WithKey(key interface{}) Encryptor
 }
@@ -22,14 +21,12 @@ type encryptor struct {
 }
 
 // NewEncryptor instantiates a new Encryptor for the CKKS scheme. The key argument can
-// be either a *rlwe.PublicKey or a *rlwe.SecretKey.
+// be *rlwe.PublicKey, *rlwe.SecretKey or nil.
 func NewEncryptor(params Parameters, key interface{}) Encryptor {
 	return &encryptor{rlwe.NewEncryptor(params.Parameters, key), params}
 }
 
-// Encrypt encrypts the input plaintext and write the result on ciphertext. The encryption
-// algorithm depends on how the receiver encryptor was initialized (see NewEncryptor
-// and NewFastEncryptor).
+// Encrypt encrypts the input plaintext and write the result on ciphertext.
 // The level of the output ciphertext is min(plaintext.Level(), ciphertext.Level()).
 func (enc *encryptor) Encrypt(plaintext *Plaintext, ciphertext *Ciphertext) {
 	enc.Encryptor.Encrypt(plaintext.Plaintext, ciphertext.Ciphertext)
@@ -37,8 +34,6 @@ func (enc *encryptor) Encrypt(plaintext *Plaintext, ciphertext *Ciphertext) {
 }
 
 // EncryptNew encrypts the input plaintext returns the result as a newly allocated ciphertext.
-// The encryption algorithm depends on how the receiver encryptor was initialized (see
-// NewEncryptor and NewFastEncryptor).
 // The level of the output ciphertext is min(plaintext.Level(), ciphertext.Level()).
 func (enc *encryptor) EncryptNew(plaintext *Plaintext) (ciphertext *Ciphertext) {
 	ciphertext = NewCiphertext(enc.params, 1, plaintext.Level(), plaintext.Scale)
@@ -47,6 +42,8 @@ func (enc *encryptor) EncryptNew(plaintext *Plaintext) (ciphertext *Ciphertext) 
 }
 
 // EncryptFromCRP encrypts the input plaintext and writes the result in ciphertext.
+// This method of encryption only works if the encryptor has been instantiated with
+// a secret key.
 // The passed crp is always treated as being in the NTT domain and the level of the output ciphertext is
 // min(plaintext.Level(), ciphertext.Level()).
 func (enc *encryptor) EncryptFromCRP(plaintext *Plaintext, crp *ring.Poly, ciphertext *Ciphertext) {
@@ -55,6 +52,8 @@ func (enc *encryptor) EncryptFromCRP(plaintext *Plaintext, crp *ring.Poly, ciphe
 }
 
 // EncryptFromCRPNew encrypts the input plaintext and returns the result as a newly allocated ciphertext.
+// This method of encryption only works if the encryptor has been instantiated with
+// a secret key.
 // The passed crp is always treated as being in the NTT domain and the level of the output ciphertext is
 // min(plaintext.Level(), ciphertext.Level()).
 func (enc *encryptor) EncryptFromCRPNew(plaintext *Plaintext, crp *ring.Poly) (ciphertext *Ciphertext) {
@@ -70,8 +69,10 @@ func (enc *encryptor) ShallowCopy() Encryptor {
 	return &encryptor{enc.Encryptor.ShallowCopy(), enc.params}
 }
 
-// WithKey creates a shallow copy of the receiver Encryptor with the provided key.
-// This is equivalent to calling Encryptor.ShallowCopy().WithKey(*)
+// ShallowCopy creates a shallow copy of this encryptor with a new key in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Encryptors can be used concurrently.
+// Key can be *rlwe.PublicKey or *rlwe.SecretKey.
 func (enc *encryptor) WithKey(key interface{}) Encryptor {
 	return &encryptor{enc.Encryptor.WithKey(key), enc.params}
 }

--- a/ckks/evaluator.go
+++ b/ckks/evaluator.go
@@ -240,39 +240,6 @@ func (eval *evaluator) GetKeySwitcher() *rlwe.KeySwitcher {
 	return eval.KeySwitcher
 }
 
-// ShallowCopy creates a shallow copy of this evaluator in which all the read-only data-structures are
-// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
-// Evaluators can be used concurrently.
-func (eval *evaluator) ShallowCopy() Evaluator {
-	return &evaluator{
-		evaluatorBase:    eval.evaluatorBase,
-		KeySwitcher:      eval.KeySwitcher.ShallowCopy(),
-		evaluatorBuffers: newEvaluatorBuffers(eval.evaluatorBase),
-		rlk:              eval.rlk,
-		rtks:             eval.rtks,
-		permuteNTTIndex:  eval.permuteNTTIndex,
-	}
-}
-
-// WithKey creates a shallow copy of the receiver Evaluator for which the new EvaluationKey is evaluationKey
-// and where the temporary buffers are shared. The receiver and the returned Evaluators cannot be used concurrently.
-func (eval *evaluator) WithKey(evaluationKey rlwe.EvaluationKey) Evaluator {
-	var indexes map[uint64][]uint64
-	if evaluationKey.Rtks == eval.rtks {
-		indexes = eval.permuteNTTIndex
-	} else {
-		indexes = *eval.permuteNTTIndexesForKey(evaluationKey.Rtks)
-	}
-	return &evaluator{
-		KeySwitcher:      eval.KeySwitcher,
-		evaluatorBase:    eval.evaluatorBase,
-		evaluatorBuffers: eval.evaluatorBuffers,
-		rlk:              evaluationKey.Rlk,
-		rtks:             evaluationKey.Rtks,
-		permuteNTTIndex:  indexes,
-	}
-}
-
 func (eval *evaluator) checkBinary(op0, op1, opOut Operand, opOutMinDegree int) {
 	if op0 == nil || op1 == nil || opOut == nil {
 		panic("operands cannot be nil")
@@ -1603,4 +1570,37 @@ func (eval *evaluator) PermuteNTTHoisted(level int, c0, c1 *ring.Poly, c2DecompQ
 
 	ringQ.PermuteNTTWithIndexLvl(level, pool2Q, index, cOut0)
 	ringQ.PermuteNTTWithIndexLvl(level, pool3Q, index, cOut1)
+}
+
+// ShallowCopy creates a shallow copy of this evaluator in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Evaluators can be used concurrently.
+func (eval *evaluator) ShallowCopy() Evaluator {
+	return &evaluator{
+		evaluatorBase:    eval.evaluatorBase,
+		KeySwitcher:      eval.KeySwitcher.ShallowCopy(),
+		evaluatorBuffers: newEvaluatorBuffers(eval.evaluatorBase),
+		rlk:              eval.rlk,
+		rtks:             eval.rtks,
+		permuteNTTIndex:  eval.permuteNTTIndex,
+	}
+}
+
+// WithKey creates a shallow copy of the receiver Evaluator for which the new EvaluationKey is evaluationKey
+// and where the temporary buffers are shared. The receiver and the returned Evaluators cannot be used concurrently.
+func (eval *evaluator) WithKey(evaluationKey rlwe.EvaluationKey) Evaluator {
+	var indexes map[uint64][]uint64
+	if evaluationKey.Rtks == eval.rtks {
+		indexes = eval.permuteNTTIndex
+	} else {
+		indexes = *eval.permuteNTTIndexesForKey(evaluationKey.Rtks)
+	}
+	return &evaluator{
+		KeySwitcher:      eval.KeySwitcher,
+		evaluatorBase:    eval.evaluatorBase,
+		evaluatorBuffers: eval.evaluatorBuffers,
+		rlk:              evaluationKey.Rlk,
+		rtks:             evaluationKey.Rtks,
+		permuteNTTIndex:  indexes,
+	}
 }

--- a/ckks/linear_transform.go
+++ b/ckks/linear_transform.go
@@ -615,8 +615,8 @@ func (eval *evaluator) InnerSumLog(ctIn *Ciphertext, batchSize, n int, ctOut *Ci
 
 					// if n is not a power of two
 					if n&(n-1) != 0 {
-						eval.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, c0OutQP.Q, c0OutQP.P, c0OutQP.Q) // Division by P
-						eval.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, c1OutQP.Q, c1OutQP.P, c1OutQP.Q) // Division by P
+						eval.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, c0OutQP.Q, c0OutQP.P, c0OutQP.Q) // Division by P
+						eval.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, c1OutQP.Q, c1OutQP.P, c1OutQP.Q) // Division by P
 
 						// ctOut += (tmpc0, tmpc1)
 						ringQ.AddLvl(levelQ, c0OutQP.Q, tmpc0, ctOut.Value[0])
@@ -737,8 +737,8 @@ func (eval *evaluator) InnerSum(ctIn *Ciphertext, batchSize, n int, ctOut *Ciphe
 		}
 
 		// Division by P of sum(elements [2, ..., n-1] )
-		eval.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, tmp0QP.Q, tmp0QP.P, tmp0QP.Q) // sum_{i=1, n-1}(phi(d0))/P
-		eval.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, tmp1QP.Q, tmp1QP.P, tmp1QP.Q) // sum_{i=1, n-1}(phi(d1))/P
+		eval.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, tmp0QP.Q, tmp0QP.P, tmp0QP.Q) // sum_{i=1, n-1}(phi(d0))/P
+		eval.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, tmp1QP.Q, tmp1QP.P, tmp1QP.Q) // sum_{i=1, n-1}(phi(d1))/P
 
 		// Adds element[1] (which did not require rotation)
 		ringQ.AddLvl(levelQ, ctIn.Value[0], tmp0QP.Q, ctOut.Value[0]) // sum_{i=1, n-1}(phi(d0))/P + ct0
@@ -861,8 +861,8 @@ func (eval *evaluator) MultiplyByDiagMatrix(ctIn *Ciphertext, matrix LinearTrans
 		ringP.ReduceLvl(levelP, c1OutQP.P, c1OutQP.P)
 	}
 
-	eval.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, c0OutQP.Q, c0OutQP.P, c0OutQP.Q) // sum(phi(c0 * P + d0_QP))/P
-	eval.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, c1OutQP.Q, c1OutQP.P, c1OutQP.Q) // sum(phi(d1_QP))/P
+	eval.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, c0OutQP.Q, c0OutQP.P, c0OutQP.Q) // sum(phi(c0 * P + d0_QP))/P
+	eval.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, c1OutQP.Q, c1OutQP.P, c1OutQP.Q) // sum(phi(d1_QP))/P
 
 	if state { // Rotation by zero
 		ringQ.MulCoeffsMontgomeryAndAddLvl(levelQ, matrix.Vec[0].Q, ctInTmp0, c0OutQP.Q) // ctOut += c0_Q * plaintext
@@ -971,7 +971,7 @@ func (eval *evaluator) MultiplyByDiagMatrixBSGS(ctIn *Ciphertext, matrix LinearT
 		if j != 0 {
 
 			// Hoisting of the ModDown of sum(sum(phi(d1) * plaintext))
-			eval.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, tmp1QP.Q, tmp1QP.P, tmp1QP.Q) // c1 * plaintext + sum(phi(d1) * plaintext) + phi(c1) * plaintext mod Q
+			eval.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, tmp1QP.Q, tmp1QP.P, tmp1QP.Q) // c1 * plaintext + sum(phi(d1) * plaintext) + phi(c1) * plaintext mod Q
 
 			galEl := eval.params.GaloisElementForColumnRotationBy(j)
 
@@ -1029,8 +1029,8 @@ func (eval *evaluator) MultiplyByDiagMatrixBSGS(ctIn *Ciphertext, matrix LinearT
 		ringP.ReduceLvl(levelP, c1OutQP.P, c1OutQP.P)
 	}
 
-	eval.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, ctOut.Value[0], c0OutQP.P, ctOut.Value[0]) // sum(phi(c0 * P + d0_QP))/P
-	eval.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, ctOut.Value[1], c1OutQP.P, ctOut.Value[1]) // sum(phi(d1_QP))/P
+	eval.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, ctOut.Value[0], c0OutQP.P, ctOut.Value[0]) // sum(phi(c0 * P + d0_QP))/P
+	eval.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, ctOut.Value[1], c1OutQP.P, ctOut.Value[1]) // sum(phi(d1_QP))/P
 
 	ctOut.Scale = matrix.Scale * ctIn.Scale
 

--- a/ckks/polynomial_evaluation.go
+++ b/ckks/polynomial_evaluation.go
@@ -96,7 +96,7 @@ type polynomialVector struct {
 	SlotsIndex map[int][]int
 }
 
-// EvaluatePoly evaluates a vector of Polyomials on the input Ciphertext in ceil(log2(deg+1)) levels.
+// EvaluatePolyVector evaluates a vector of Polyomials on the input Ciphertext in ceil(log2(deg+1)) levels.
 // Returns an error if the input ciphertext does not have enough level to carry out the full polynomial evaluation.
 // Returns an error if something is wrong with the scale.
 // Returns an error if polynomials are not all in the same basis.
@@ -107,9 +107,9 @@ type polynomialVector struct {
 // if the polynomial is "even" or "odd" (to ensure that the even or odd property remains valid
 // after the "splitCoeffs" polynomial decomposition).
 // Inputs:
-// pols: a slice of N *Polynomial, indexed from 0 to N-1.
+// pols: a slice of up to 'n' *Polynomial ('n' being the maximum number of slots), indexed from 0 to n-1.
 // encoder: an Encoder.
-// slotsIndex: a map[int][]int indexing as key the polynomial to evalute and as value the index of the slots on which to evaluate the polynomial index by the key.
+// slotsIndex: a map[int][]int indexing as key the polynomial to evalute and as value the index of the slots on which to evaluate the polynomial indexed by the key.
 //
 // Example: if pols = []*Polynomial{pol0, pol1} and slotsIndex = map[int][]int:{0:[1, 2, 4, 5, 7], 1:[0, 3]},
 // then pol0 will be applied to slots [1, 2, 4, 5, 7], pol1 to slots [0, 3] and the slot 6 will be zero-ed.

--- a/ckks/precision.go
+++ b/ckks/precision.go
@@ -36,7 +36,7 @@ type Stats struct {
 func (prec PrecisionStats) String() string {
 	return fmt.Sprintf(`
 ┌─────────┬───────┬───────┬───────┐
-│    Log2 │ REAL  │ IMAG  │  L2   │
+│    Log2 │ REAL  │ IMAG  │ L2    │
 ├─────────┼───────┼───────┼───────┤
 │MIN Prec │ %.2f │ %.2f │ %.2f │
 │MAX Prec │ %.2f │ %.2f │ %.2f │

--- a/ckks/precision.go
+++ b/ckks/precision.go
@@ -34,16 +34,24 @@ type Stats struct {
 }
 
 func (prec PrecisionStats) String() string {
-	return fmt.Sprintf("\n _________________________________\n") +
-		fmt.Sprintf("|    Log2 | REAL  | IMAG  | L2    |\n") +
-		fmt.Sprintf("|MIN Prec | %.2f | %.2f | %.2f |\n", prec.MinPrecision.Real, prec.MinPrecision.Imag, prec.MinPrecision.L2) +
-		fmt.Sprintf("|MAX Prec | %.2f | %.2f | %.2f |\n", prec.MaxPrecision.Real, prec.MaxPrecision.Imag, prec.MaxPrecision.L2) +
-		fmt.Sprintf("|AVG Prec | %.2f | %.2f | %.2f |\n", prec.MeanPrecision.Real, prec.MeanPrecision.Imag, prec.MeanPrecision.L2) +
-		fmt.Sprintf("|MED Prec | %.2f | %.2f | %.2f |\n", prec.MedianPrecision.Real, prec.MedianPrecision.Imag, prec.MedianPrecision.L2) +
-		fmt.Sprintf("===================================\n") +
-		fmt.Sprintf("Err STD Slots  : %5.2f Log2 \n", math.Log2(prec.STDFreq)) +
-		fmt.Sprintf("Err STD Coeffs : %5.2f Log2 \n", math.Log2(prec.STDTime))
-
+	return fmt.Sprintf(`
+┌─────────┬───────┬───────┬───────┐
+│    Log2 │ REAL  │ IMAG  │  L2   │
+├─────────┼───────┼───────┼───────┤
+│MIN Prec │ %.2f │ %.2f │ %.2f │
+│MAX Prec │ %.2f │ %.2f │ %.2f │
+│AVG Prec │ %.2f │ %.2f │ %.2f │
+│MED Prec │ %.2f │ %.2f │ %.2f │
+└─────────┴───────┴───────┴───────┘
+Err STD Slots  : %5.2f Log2
+Err STD Coeffs : %5.2f Log2
+`,
+		prec.MinPrecision.Real, prec.MinPrecision.Imag, prec.MinPrecision.L2,
+		prec.MaxPrecision.Real, prec.MaxPrecision.Imag, prec.MaxPrecision.L2,
+		prec.MeanPrecision.Real, prec.MeanPrecision.Imag, prec.MeanPrecision.L2,
+		prec.MedianPrecision.Real, prec.MedianPrecision.Imag, prec.MedianPrecision.L2,
+		math.Log2(prec.STDFreq),
+		math.Log2(prec.STDTime))
 }
 
 // GetPrecisionStats generates a PrecisionStats struct from the reference values and the decrypted values

--- a/ckks/utils.go
+++ b/ckks/utils.go
@@ -1,9 +1,10 @@
 package ckks
 
 import (
-	"github.com/ldsec/lattigo/v2/ring"
 	"math"
 	"math/big"
+
+	"github.com/ldsec/lattigo/v2/ring"
 )
 
 // StandardDeviation computes the scaled standard deviation of the input vector.
@@ -27,7 +28,7 @@ func StandardDeviation(vec []float64, scale float64) (std float64) {
 	return math.Sqrt(err/n) * scale
 }
 
-// NttAndMontgomeryLvl takes maps the polynomial polIn Z[Y] outside of the NTT domain to the polynomial Z[X] in the NTT domain where Y = X^(gap).
+// NttAndMontgomeryLvl takes the polynomial polIn Z[Y] outside of the NTT domain to the polynomial Z[X] in the NTT domain where Y = X^(gap).
 // This method is used to accelerate the NTT of polynomials that encode sparse plaintexts.
 func NttAndMontgomeryLvl(level int, logSlots int, ringQ *ring.Ring, montgomery bool, pol *ring.Poly) {
 

--- a/ckks/utils.go
+++ b/ckks/utils.go
@@ -27,6 +27,52 @@ func StandardDeviation(vec []float64, scale float64) (std float64) {
 	return math.Sqrt(err/n) * scale
 }
 
+// NttAndMontgomeryLvl takes maps the polynomial polIn Z[Y] outside of the NTT domain to the polynomial Z[X] in the NTT domain where Y = X^(gap).
+// This method is used to accelerate the NTT of polynomials that encode sparse plaintexts.
+func NttAndMontgomeryLvl(level int, logSlots int, ringQ *ring.Ring, montgomery bool, pol *ring.Poly) {
+
+	if 1<<logSlots == ringQ.NthRoot>>2 {
+		ringQ.NTTLvl(level, pol, pol)
+		if montgomery {
+			ringQ.MFormLvl(level, pol, pol)
+		}
+	} else {
+
+		var n int
+		var NTT func(coeffsIn, coeffsOut []uint64, N int, nttPsi []uint64, Q, QInv uint64, bredParams []uint64)
+		switch ringQ.Type() {
+		case ring.Standard:
+			n = 2 << logSlots
+			NTT = ring.NTT
+		case ring.ConjugateInvariant:
+			n = 1 << logSlots
+			NTT = ring.NTTConjugateInvariant
+		}
+
+		N := ringQ.N
+		gap := N / n
+		for i := 0; i < level+1; i++ {
+
+			coeffs := pol.Coeffs[i]
+
+			// NTT in dimension n
+			NTT(coeffs[:n], coeffs[:n], n, ringQ.NttPsi[i], ringQ.Modulus[i], ringQ.MredParams[i], ringQ.BredParams[i])
+
+			if montgomery {
+				ring.MFormVec(coeffs[:n], coeffs[:n], ringQ.Modulus[i], ringQ.BredParams[i])
+			}
+
+			// Maps NTT in dimension n to NTT in dimension N
+			for j := n - 1; j >= 0; j-- {
+				c := coeffs[j]
+				for w := 0; w < gap; w++ {
+					coeffs[j*gap+w] = c
+				}
+			}
+		}
+	}
+}
+
 func interfaceMod(x interface{}, qi uint64) uint64 {
 
 	switch x := x.(type) {

--- a/dbfv/dbfv_benchmark_test.go
+++ b/dbfv/dbfv_benchmark_test.go
@@ -53,7 +53,7 @@ func benchPublicKeyGen(testCtx *testContext, b *testing.B) {
 	p := new(Party)
 	p.CKGProtocol = NewCKGProtocol(testCtx.params)
 	p.s = sk0Shards[0]
-	p.s1 = p.AllocateShares()
+	p.s1 = p.AllocateShare()
 
 	crp := p.SampleCRP(testCtx.crs)
 
@@ -67,7 +67,7 @@ func benchPublicKeyGen(testCtx *testContext, b *testing.B) {
 	b.Run(testString("PublicKeyGen/Round1/Agg", parties, testCtx.params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.s1, p.s1, p.s1)
+			p.AggregateShare(p.s1, p.s1, p.s1)
 		}
 	})
 
@@ -96,7 +96,7 @@ func benchRelinKeyGen(testCtx *testContext, b *testing.B) {
 	p := new(Party)
 	p.RKGProtocol = NewRKGProtocol(testCtx.params)
 	p.sk = sk0Shards[0]
-	p.ephSk, p.share1, p.share2 = p.RKGProtocol.AllocateShares()
+	p.ephSk, p.share1, p.share2 = p.RKGProtocol.AllocateShare()
 	p.rlk = bfv.NewRelinearizationKey(testCtx.params, 2)
 
 	crp := p.SampleCRP(testCtx.crs)
@@ -109,7 +109,7 @@ func benchRelinKeyGen(testCtx *testContext, b *testing.B) {
 
 	b.Run(testString("RelinKeyGen/Round1/Agg", parties, testCtx.params), func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.share1, p.share1, p.share1)
+			p.AggregateShare(p.share1, p.share1, p.share1)
 		}
 	})
 
@@ -121,7 +121,7 @@ func benchRelinKeyGen(testCtx *testContext, b *testing.B) {
 
 	b.Run(testString("RelinKeyGen/Round2/Agg", parties, testCtx.params), func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.share2, p.share2, p.share2)
+			p.AggregateShare(p.share2, p.share2, p.share2)
 		}
 	})
 
@@ -162,7 +162,7 @@ func benchKeyswitching(testCtx *testContext, b *testing.B) {
 	b.Run(testString("Keyswitching/Round1/Agg", parties, testCtx.params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.share, p.share, p.share)
+			p.AggregateShare(p.share, p.share, p.share)
 		}
 	})
 
@@ -203,7 +203,7 @@ func benchPublicKeySwitching(testCtx *testContext, b *testing.B) {
 	b.Run(testString("PublicKeySwitching/Round1/Agg", parties, testCtx.params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.share, p.share, p.share)
+			p.AggregateShare(p.share, p.share, p.share)
 		}
 	})
 
@@ -228,7 +228,7 @@ func benchRotKeyGen(testCtx *testContext, b *testing.B) {
 	p := new(Party)
 	p.RTGProtocol = NewRotKGProtocol(testCtx.params)
 	p.s = sk0Shards[0]
-	p.share = p.AllocateShares()
+	p.share = p.AllocateShare()
 
 	crp := p.SampleCRP(testCtx.crs)
 
@@ -242,7 +242,7 @@ func benchRotKeyGen(testCtx *testContext, b *testing.B) {
 	b.Run(testString("RotKeyGen/Round1/Agg", parties, testCtx.params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.share, p.share, p.share)
+			p.AggregateShare(p.share, p.share, p.share)
 		}
 	})
 
@@ -277,7 +277,7 @@ func benchRefresh(testCtx *testContext, b *testing.B) {
 	b.Run(testString("Refresh/Round1/Gen", parties, testCtx.params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.GenShares(p.s, ciphertext.Value[1], crp, p.share)
+			p.GenShare(p.s, ciphertext.Value[1], crp, p.share)
 		}
 	})
 

--- a/dbfv/dbfv_benchmark_test.go
+++ b/dbfv/dbfv_benchmark_test.go
@@ -242,7 +242,7 @@ func benchRotKeyGen(testCtx *testContext, b *testing.B) {
 	b.Run(testString("RotKeyGen/Round1/Agg", parties, testCtx.params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.Aggregate(p.share, p.share, p.share)
+			p.AggregateShares(p.share, p.share, p.share)
 		}
 	})
 

--- a/dbfv/dbfv_benchmark_test.go
+++ b/dbfv/dbfv_benchmark_test.go
@@ -150,12 +150,12 @@ func benchKeyswitching(testCtx *testContext, b *testing.B) {
 	p.CKSProtocol = NewCKSProtocol(testCtx.params, 6.36)
 	p.s0 = sk0Shards[0]
 	p.s1 = sk1Shards[0]
-	p.share = p.AllocateShare(ciphertext.Level())
+	p.share = p.AllocateShare()
 
 	b.Run(testString("Keyswitching/Round1/Gen", parties, testCtx.params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.GenShare(p.s0, p.s1, ciphertext.Ciphertext, p.share)
+			p.GenShare(p.s0, p.s1, ciphertext.Value[1], p.share)
 		}
 	})
 
@@ -169,7 +169,7 @@ func benchKeyswitching(testCtx *testContext, b *testing.B) {
 	b.Run(testString("Keyswitching/Finalize", parties, testCtx.params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.KeySwitch(p.share, ciphertext.Ciphertext, ciphertext.Ciphertext)
+			p.KeySwitch(ciphertext, p.share, ciphertext)
 		}
 	})
 }
@@ -190,12 +190,12 @@ func benchPublicKeySwitching(testCtx *testContext, b *testing.B) {
 	p := new(Party)
 	p.PCKSProtocol = NewPCKSProtocol(testCtx.params, 6.36)
 	p.s = sk0Shards[0]
-	p.share = p.AllocateShare(ciphertext.Level())
+	p.share = p.AllocateShare()
 
 	b.Run(testString("PublicKeySwitching/Round1/Gen", parties, testCtx.params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.GenShare(p.s, pk1, ciphertext.Ciphertext, p.share)
+			p.GenShare(p.s, pk1, ciphertext.Value[1], p.share)
 
 		}
 	})
@@ -210,7 +210,7 @@ func benchPublicKeySwitching(testCtx *testContext, b *testing.B) {
 	b.Run(testString("PublicKeySwitching/Finalize", parties, testCtx.params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.KeySwitch(p.share, ciphertext.Ciphertext, ciphertext.Ciphertext)
+			p.KeySwitch(ciphertext, p.share, ciphertext)
 		}
 	})
 }
@@ -277,7 +277,7 @@ func benchRefresh(testCtx *testContext, b *testing.B) {
 	b.Run(testString("Refresh/Round1/Gen", parties, testCtx.params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.GenShares(p.s, ciphertext, crp, p.share)
+			p.GenShares(p.s, ciphertext.Value[1], crp, p.share)
 		}
 	})
 

--- a/dbfv/dbfv_test.go
+++ b/dbfv/dbfv_test.go
@@ -630,7 +630,7 @@ func testRefresh(testCtx *testContext, t *testing.T) {
 
 		// Simulated added error of size Q/(T^2) and add it to the fresh ciphertext
 		coeffsBigint := make([]*big.Int, testCtx.params.N())
-		testCtx.ringQ.PolyToBigint(ciphertext.Value[0], coeffsBigint)
+		testCtx.ringQ.PolyToBigint(ciphertext.Value[0], 1, coeffsBigint)
 
 		errorRange := new(big.Int).Set(testCtx.ringQ.ModulusBigint)
 		errorRange.Quo(errorRange, testCtx.ringT.ModulusBigint)

--- a/dbfv/dbfv_test.go
+++ b/dbfv/dbfv_test.go
@@ -400,7 +400,7 @@ func testRotKeyGenRotRows(testCtx *testContext, t *testing.T) {
 		for i, p := range pcksParties {
 			p.GenShare(p.s, galEl, crp, p.share)
 			if i > 0 {
-				P0.Aggregate(p.share, P0.share, P0.share)
+				P0.AggregateShares(p.share, P0.share, P0.share)
 			}
 		}
 
@@ -457,7 +457,7 @@ func testRotKeyGenRotCols(testCtx *testContext, t *testing.T) {
 			for i, p := range pcksParties {
 				p.GenShare(p.s, galEl, crp, p.share)
 				if i > 0 {
-					P0.Aggregate(p.share, P0.share, P0.share)
+					P0.AggregateShares(p.share, P0.share, P0.share)
 				}
 			}
 

--- a/dbfv/keygen.go
+++ b/dbfv/keygen.go
@@ -13,9 +13,14 @@ type CKGProtocol struct {
 
 // NewCKGProtocol creates a new CKGProtocol instance
 func NewCKGProtocol(params bfv.Parameters) *CKGProtocol {
-	ckg := new(CKGProtocol)
-	ckg.CKGProtocol = *drlwe.NewCKGProtocol(params.Parameters)
-	return ckg
+	return &CKGProtocol{*drlwe.NewCKGProtocol(params.Parameters)}
+}
+
+// ShallowCopy creates a shallow copy of CKGProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// CKGProtocol can be used concurrently.
+func (ckg *CKGProtocol) ShallowCopy() *CKGProtocol {
+	return &CKGProtocol{*ckg.CKGProtocol.ShallowCopy()}
 }
 
 // RKGProtocol is the structure storing the parameters and state for a party in the collective relinearization key
@@ -30,6 +35,13 @@ func NewRKGProtocol(params bfv.Parameters) *RKGProtocol {
 	return &RKGProtocol{*drlwe.NewRKGProtocol(params.Parameters, 0.5)}
 }
 
+// ShallowCopy creates a shallow copy of RKGProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// RKGProtocol can be used concurrently.
+func (rkg *RKGProtocol) ShallowCopy() *RKGProtocol {
+	return &RKGProtocol{*rkg.RKGProtocol.ShallowCopy()}
+}
+
 // RTGProtocol is the structure storing the parameters for the collective rotation-keys generation.
 type RTGProtocol struct {
 	drlwe.RTGProtocol
@@ -38,4 +50,11 @@ type RTGProtocol struct {
 // NewRotKGProtocol creates a new rotkg object and will be used to generate collective rotation-keys from a shared secret-key among j parties.
 func NewRotKGProtocol(params bfv.Parameters) (rtg *RTGProtocol) {
 	return &RTGProtocol{*drlwe.NewRTGProtocol(params.Parameters)}
+}
+
+// ShallowCopy creates a shallow copy of RTGProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// RTGProtocol can be used concurrently.
+func (rtg *RTGProtocol) ShallowCopy() *RTGProtocol {
+	return &RTGProtocol{*rtg.RTGProtocol.ShallowCopy()}
 }

--- a/dbfv/keygen.go
+++ b/dbfv/keygen.go
@@ -32,7 +32,7 @@ type RKGProtocol struct {
 // NewRKGProtocol creates a new RKGProtocol object that will be used to generate a collective evaluation-key
 // among j parties in the given context with the given bit-decomposition.
 func NewRKGProtocol(params bfv.Parameters) *RKGProtocol {
-	return &RKGProtocol{*drlwe.NewRKGProtocol(params.Parameters, 0.5)}
+	return &RKGProtocol{*drlwe.NewRKGProtocol(params.Parameters)}
 }
 
 // ShallowCopy creates a shallow copy of RKGProtocol in which all the read-only data-structures are

--- a/dbfv/keyswitch.go
+++ b/dbfv/keyswitch.go
@@ -18,9 +18,14 @@ func NewCKSProtocol(params bfv.Parameters, sigmaSmudging float64) *CKSProtocol {
 	return &CKSProtocol{*drlwe.NewCKSProtocol(params.Parameters, sigmaSmudging), params.MaxLevel()}
 }
 
-// AllocateShareBFV allocates the shares of one party in the CKS protocol for BFV.
-func (cks *CKSProtocol) AllocateShareBFV() *drlwe.CKSShare {
-	return cks.AllocateShare(cks.maxLevel)
+// KeySwitch performs the actual keyswitching operation on a ciphertext ct and put the result in ctOut
+func (cks *CKSProtocol) KeySwitch(ctIn *bfv.Ciphertext, combined *drlwe.CKSShare, ctOut *bfv.Ciphertext) {
+	cks.CKSProtocol.KeySwitch(ctIn.Ciphertext, combined, ctOut.Ciphertext)
+}
+
+// AllocateShare allocates the shares of one party in the CKS protocol for BFV.
+func (cks *CKSProtocol) AllocateShare() *drlwe.CKSShare {
+	return cks.CKSProtocol.AllocateShare(cks.maxLevel)
 }
 
 // ShallowCopy creates a shallow copy of CKSProtocol in which all the read-only data-structures are
@@ -42,9 +47,14 @@ func NewPCKSProtocol(params bfv.Parameters, sigmaSmudging float64) *PCKSProtocol
 	return &PCKSProtocol{*drlwe.NewPCKSProtocol(params.Parameters, sigmaSmudging), params.MaxLevel()}
 }
 
-// AllocateShareBFV allocates the shares of one party in the PCKS protocol for BFV.
-func (pcks *PCKSProtocol) AllocateShareBFV() *drlwe.PCKSShare {
-	return pcks.AllocateShare(pcks.maxLevel)
+// AllocateShare allocates the shares of one party in the PCKS protocol for BFV.
+func (pcks *PCKSProtocol) AllocateShare() *drlwe.PCKSShare {
+	return pcks.PCKSProtocol.AllocateShare(pcks.maxLevel)
+}
+
+// KeySwitch performs the actual keyswitching operation on a ciphertext ct and put the result in ctOut.
+func (pcks *PCKSProtocol) KeySwitch(ctIn *bfv.Ciphertext, combined *drlwe.PCKSShare, ctOut *bfv.Ciphertext) {
+	pcks.PCKSProtocol.KeySwitch(ctIn.Ciphertext, combined, ctOut.Ciphertext)
 }
 
 // ShallowCopy creates a shallow copy of PCKSProtocol in which all the read-only data-structures are

--- a/dbfv/keyswitch.go
+++ b/dbfv/keyswitch.go
@@ -8,36 +8,34 @@ import (
 // CKSProtocol is a structure storing the parameters for the collective key-switching protocol.
 type CKSProtocol struct {
 	drlwe.CKSProtocol
-
-	params bfv.Parameters
+	maxLevel int
 }
 
 // NewCKSProtocol creates a new CKSProtocol that will be used to operate a collective key-switching on a ciphertext encrypted under a collective public-key, whose
 // secret-shares are distributed among j parties, re-encrypting the ciphertext under another public-key, whose secret-shares are also known to the
 // parties.
 func NewCKSProtocol(params bfv.Parameters, sigmaSmudging float64) *CKSProtocol {
-	return &CKSProtocol{*drlwe.NewCKSProtocol(params.Parameters, sigmaSmudging), params}
+	return &CKSProtocol{*drlwe.NewCKSProtocol(params.Parameters, sigmaSmudging), params.MaxLevel()}
 }
 
 // AllocateShareBFV allocates the shares of one party in the CKS protocol for BFV.
 func (pcks *CKSProtocol) AllocateShareBFV() *drlwe.CKSShare {
-	return pcks.AllocateShare(pcks.params.MaxLevel())
+	return pcks.AllocateShare(pcks.maxLevel)
 }
 
 // PCKSProtocol is the structure storing the parameters for the collective public key-switching.
 type PCKSProtocol struct {
 	drlwe.PCKSProtocol
-
-	params bfv.Parameters
+	maxLevel int
 }
 
 // NewPCKSProtocol creates a new PCKSProtocol object and will be used to re-encrypt a ciphertext ctx encrypted under a secret-shared key among j parties under a new
 // collective public-key.
 func NewPCKSProtocol(params bfv.Parameters, sigmaSmudging float64) *PCKSProtocol {
-	return &PCKSProtocol{*drlwe.NewPCKSProtocol(params.Parameters, sigmaSmudging), params}
+	return &PCKSProtocol{*drlwe.NewPCKSProtocol(params.Parameters, sigmaSmudging), params.MaxLevel()}
 }
 
 // AllocateShareBFV allocates the shares of one party in the PCKS protocol for BFV.
 func (pcks *PCKSProtocol) AllocateShareBFV() *drlwe.PCKSShare {
-	return pcks.AllocateShare(pcks.params.MaxLevel())
+	return pcks.AllocateShare(pcks.maxLevel)
 }

--- a/dbfv/keyswitch.go
+++ b/dbfv/keyswitch.go
@@ -19,8 +19,15 @@ func NewCKSProtocol(params bfv.Parameters, sigmaSmudging float64) *CKSProtocol {
 }
 
 // AllocateShareBFV allocates the shares of one party in the CKS protocol for BFV.
-func (pcks *CKSProtocol) AllocateShareBFV() *drlwe.CKSShare {
-	return pcks.AllocateShare(pcks.maxLevel)
+func (cks *CKSProtocol) AllocateShareBFV() *drlwe.CKSShare {
+	return cks.AllocateShare(cks.maxLevel)
+}
+
+// ShallowCopy creates a shallow copy of CKSProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// CKSProtocol can be used concurrently.
+func (cks *CKSProtocol) ShallowCopy() *CKSProtocol {
+	return &CKSProtocol{*cks.CKSProtocol.ShallowCopy(), cks.maxLevel}
 }
 
 // PCKSProtocol is the structure storing the parameters for the collective public key-switching.
@@ -38,4 +45,11 @@ func NewPCKSProtocol(params bfv.Parameters, sigmaSmudging float64) *PCKSProtocol
 // AllocateShareBFV allocates the shares of one party in the PCKS protocol for BFV.
 func (pcks *PCKSProtocol) AllocateShareBFV() *drlwe.PCKSShare {
 	return pcks.AllocateShare(pcks.maxLevel)
+}
+
+// ShallowCopy creates a shallow copy of PCKSProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// PCKSProtocol can be used concurrently.
+func (pcks *PCKSProtocol) ShallowCopy() *PCKSProtocol {
+	return &PCKSProtocol{*pcks.PCKSProtocol.ShallowCopy(), pcks.maxLevel}
 }

--- a/dbfv/keyswitch.go
+++ b/dbfv/keyswitch.go
@@ -11,7 +11,7 @@ type CKSProtocol struct {
 	maxLevel int
 }
 
-// NewCKSProtocol creates a new CKSProtocol that will be used to operate a collective key-switching on a ciphertext encrypted under a collective public-key, whose
+// NewCKSProtocol creates a new CKSProtocol that will be used to perform a collective key-switching on a ciphertext encrypted under a collective public-key, whose
 // secret-shares are distributed among j parties, re-encrypting the ciphertext under another public-key, whose secret-shares are also known to the
 // parties.
 func NewCKSProtocol(params bfv.Parameters, sigmaSmudging float64) *CKSProtocol {

--- a/dbfv/refresh.go
+++ b/dbfv/refresh.go
@@ -37,10 +37,10 @@ func (rfp *RefreshProtocol) AllocateShare() *RefreshShare {
 	return &RefreshShare{*share}
 }
 
-// GenShares generates a share for the Refresh protocol.
-// c1 = ciphertext.Value[1]
-func (rfp *RefreshProtocol) GenShares(sk *rlwe.SecretKey, c1 *ring.Poly, crp drlwe.CKSCRP, shareOut *RefreshShare) {
-	rfp.MaskedTransformProtocol.GenShares(sk, c1, crp, nil, &shareOut.MaskedTransformShare)
+// GenShare generates a share for the Refresh protocol.
+// ct1 is degree 1 element of a bfv.Ciphertext, i.e. bfv.Ciphertext.Value[1].
+func (rfp *RefreshProtocol) GenShare(sk *rlwe.SecretKey, ct1 *ring.Poly, crp drlwe.CKSCRP, shareOut *RefreshShare) {
+	rfp.MaskedTransformProtocol.GenShare(sk, ct1, crp, nil, &shareOut.MaskedTransformShare)
 }
 
 // Aggregate aggregates two parties' shares in the Refresh protocol.

--- a/dbfv/refresh.go
+++ b/dbfv/refresh.go
@@ -3,6 +3,7 @@ package dbfv
 import (
 	"github.com/ldsec/lattigo/v2/bfv"
 	"github.com/ldsec/lattigo/v2/drlwe"
+	"github.com/ldsec/lattigo/v2/ring"
 	"github.com/ldsec/lattigo/v2/rlwe"
 )
 
@@ -37,8 +38,9 @@ func (rfp *RefreshProtocol) AllocateShare() *RefreshShare {
 }
 
 // GenShares generates a share for the Refresh protocol.
-func (rfp *RefreshProtocol) GenShares(sk *rlwe.SecretKey, ciphertext *bfv.Ciphertext, crp drlwe.CKSCRP, shareOut *RefreshShare) {
-	rfp.MaskedTransformProtocol.GenShares(sk, ciphertext, crp, nil, &shareOut.MaskedTransformShare)
+// c1 = ciphertext.Value[1]
+func (rfp *RefreshProtocol) GenShares(sk *rlwe.SecretKey, c1 *ring.Poly, crp drlwe.CKSCRP, shareOut *RefreshShare) {
+	rfp.MaskedTransformProtocol.GenShares(sk, c1, crp, nil, &shareOut.MaskedTransformShare)
 }
 
 // Aggregate aggregates two parties' shares in the Refresh protocol.
@@ -47,6 +49,6 @@ func (rfp *RefreshProtocol) Aggregate(share1, share2, shareOut *RefreshShare) {
 }
 
 // Finalize applies Decrypt, Recode and Recrypt on the input ciphertext.
-func (rfp *RefreshProtocol) Finalize(ciphertext *bfv.Ciphertext, crp drlwe.CKSCRP, share *RefreshShare, ciphertextOut *bfv.Ciphertext) {
-	rfp.MaskedTransformProtocol.Transform(ciphertext, nil, crp, &share.MaskedTransformShare, ciphertextOut)
+func (rfp *RefreshProtocol) Finalize(ctIn *bfv.Ciphertext, crp drlwe.CKSCRP, share *RefreshShare, ctOut *bfv.Ciphertext) {
+	rfp.MaskedTransformProtocol.Transform(ctIn, nil, crp, &share.MaskedTransformShare, ctOut)
 }

--- a/dbfv/refresh.go
+++ b/dbfv/refresh.go
@@ -11,6 +11,13 @@ type RefreshProtocol struct {
 	MaskedTransformProtocol
 }
 
+// ShallowCopy creates a shallow copy of RefreshProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// RefreshProtocol can be used concurrently.
+func (rfp *RefreshProtocol) ShallowCopy() *RefreshProtocol {
+	return &RefreshProtocol{*rfp.MaskedTransformProtocol.ShallowCopy()}
+}
+
 // RefreshShare is a struct storing a party's share in the Refresh protocol.
 type RefreshShare struct {
 	MaskedTransformShare

--- a/dbfv/sharing.go
+++ b/dbfv/sharing.go
@@ -35,10 +35,10 @@ func (e2s *E2SProtocol) ShallowCopy() *E2SProtocol {
 	}
 
 	return &E2SProtocol{
-		CKSProtocol:       CKSProtocol{*e2s.CKSProtocol.ShallowCopy(), params.MaxLevel()},
+		CKSProtocol:       *e2s.CKSProtocol.ShallowCopy(),
 		Parameters:        e2s.Parameters,
 		maskSampler:       ring.NewUniformSampler(prng, params.RingT()),
-		encoder:           bfv.NewEncoder(params),
+		encoder:           e2s.encoder.ShallowCopy(),
 		zero:              e2s.zero,
 		tmpPlaintextRingT: bfv.NewPlaintextRingT(params),
 		tmpPlaintext:      bfv.NewPlaintext(params),
@@ -115,8 +115,8 @@ func NewS2EProtocol(params bfv.Parameters, sigmaSmudging float64) *S2EProtocol {
 func (s2e *S2EProtocol) ShallowCopy() *S2EProtocol {
 	params := s2e.Parameters
 	return &S2EProtocol{
-		CKSProtocol:  CKSProtocol{*s2e.CKSProtocol.ShallowCopy(), params.MaxLevel()},
-		encoder:      bfv.NewEncoder(params),
+		CKSProtocol:  *s2e.CKSProtocol.ShallowCopy(),
+		encoder:      s2e.encoder.ShallowCopy(),
 		Parameters:   params,
 		zero:         s2e.zero,
 		tmpPlaintext: bfv.NewPlaintext(params),

--- a/dbfv/sharing.go
+++ b/dbfv/sharing.go
@@ -12,9 +12,8 @@ import (
 // required by the encryption-to-shares protocol.
 type E2SProtocol struct {
 	CKSProtocol
+	bfv.Parameters
 
-	ringQ       *ring.Ring
-	ringT       *ring.Ring
 	maskSampler *ring.UniformSampler
 	encoder     bfv.Encoder
 
@@ -23,18 +22,40 @@ type E2SProtocol struct {
 	tmpPlaintext      *bfv.Plaintext
 }
 
+// ShallowCopy creates a shallow copy of E2SProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// E2SProtocol can be used concurrently.
+func (e2s *E2SProtocol) ShallowCopy() *E2SProtocol {
+
+	params := e2s.Parameters
+
+	prng, err := utils.NewPRNG()
+	if err != nil {
+		panic(err)
+	}
+
+	return &E2SProtocol{
+		CKSProtocol:       CKSProtocol{*e2s.CKSProtocol.ShallowCopy(), params.MaxLevel()},
+		Parameters:        e2s.Parameters,
+		maskSampler:       ring.NewUniformSampler(prng, params.RingT()),
+		encoder:           bfv.NewEncoder(params),
+		zero:              e2s.zero,
+		tmpPlaintextRingT: bfv.NewPlaintextRingT(params),
+		tmpPlaintext:      bfv.NewPlaintext(params),
+	}
+}
+
 // NewE2SProtocol creates a new E2SProtocol struct from the passed BFV parameters.
 func NewE2SProtocol(params bfv.Parameters, sigmaSmudging float64) *E2SProtocol {
 	e2s := new(E2SProtocol)
 	e2s.CKSProtocol = *NewCKSProtocol(params, sigmaSmudging)
-	e2s.ringQ = params.RingQ()
-	e2s.ringT = params.RingT()
+	e2s.Parameters = params
 	e2s.encoder = bfv.NewEncoder(params)
 	prng, err := utils.NewPRNG()
 	if err != nil {
 		panic(err)
 	}
-	e2s.maskSampler = ring.NewUniformSampler(prng, e2s.ringT)
+	e2s.maskSampler = ring.NewUniformSampler(prng, params.RingT())
 	e2s.zero = rlwe.NewSecretKey(params.Parameters)
 	e2s.tmpPlaintext = bfv.NewPlaintext(params)
 	e2s.tmpPlaintextRingT = bfv.NewPlaintextRingT(params)
@@ -47,7 +68,7 @@ func (e2s *E2SProtocol) GenShare(sk *rlwe.SecretKey, ct *bfv.Ciphertext, secretS
 	e2s.CKSProtocol.GenShare(sk, e2s.zero, ct.Ciphertext, publicShareOut)
 	e2s.maskSampler.Read(&secretShareOut.Value)
 	e2s.encoder.ScaleUp(&bfv.PlaintextRingT{Plaintext: &rlwe.Plaintext{Value: &secretShareOut.Value}}, e2s.tmpPlaintext)
-	e2s.ringQ.Sub(publicShareOut.Value, e2s.tmpPlaintext.Value, publicShareOut.Value)
+	e2s.RingQ().Sub(publicShareOut.Value, e2s.tmpPlaintext.Value, publicShareOut.Value)
 }
 
 // GetShare is the final step of the encryption-to-share protocol. It performs the masked decryption of the target ciphertext followed by a
@@ -56,10 +77,10 @@ func (e2s *E2SProtocol) GenShare(sk *rlwe.SecretKey, ct *bfv.Ciphertext, secretS
 // Therefore, in order to obtain an additive sharing of the message, only one party should call this method, and the other parties should use
 // the secretShareOut output of the GenShare method.
 func (e2s *E2SProtocol) GetShare(secretShare *rlwe.AdditiveShare, aggregatePublicShare *drlwe.CKSShare, ct *bfv.Ciphertext, secretShareOut *rlwe.AdditiveShare) {
-	e2s.ringQ.Add(aggregatePublicShare.Value, ct.Value[0], e2s.tmpPlaintext.Value)
+	e2s.RingQ().Add(aggregatePublicShare.Value, ct.Value[0], e2s.tmpPlaintext.Value)
 	e2s.encoder.ScaleDown(e2s.tmpPlaintext, e2s.tmpPlaintextRingT)
 	if secretShare != nil {
-		e2s.ringT.Add(&secretShare.Value, e2s.tmpPlaintextRingT.Value, &secretShareOut.Value)
+		e2s.RingT().Add(&secretShare.Value, e2s.tmpPlaintextRingT.Value, &secretShareOut.Value)
 	} else {
 		secretShareOut.Value.Copy(e2s.tmpPlaintextRingT.Value)
 	}
@@ -69,8 +90,8 @@ func (e2s *E2SProtocol) GetShare(secretShare *rlwe.AdditiveShare, aggregatePubli
 // required by the shares-to-encryption protocol.
 type S2EProtocol struct {
 	CKSProtocol
+	bfv.Parameters
 
-	ringQ   *ring.Ring
 	encoder bfv.Encoder
 
 	zero         *rlwe.SecretKey
@@ -81,11 +102,25 @@ type S2EProtocol struct {
 func NewS2EProtocol(params bfv.Parameters, sigmaSmudging float64) *S2EProtocol {
 	s2e := new(S2EProtocol)
 	s2e.CKSProtocol = *NewCKSProtocol(params, sigmaSmudging)
-	s2e.ringQ = params.RingQ()
+	s2e.Parameters = params
 	s2e.encoder = bfv.NewEncoder(params)
 	s2e.zero = rlwe.NewSecretKey(params.Parameters)
 	s2e.tmpPlaintext = bfv.NewPlaintext(params)
 	return s2e
+}
+
+// ShallowCopy creates a shallow copy of S2EProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// S2EProtocol can be used concurrently.
+func (s2e *S2EProtocol) ShallowCopy() *S2EProtocol {
+	params := s2e.Parameters
+	return &S2EProtocol{
+		CKSProtocol:  CKSProtocol{*s2e.CKSProtocol.ShallowCopy(), params.MaxLevel()},
+		encoder:      bfv.NewEncoder(params),
+		Parameters:   params,
+		zero:         s2e.zero,
+		tmpPlaintext: bfv.NewPlaintext(params),
+	}
 }
 
 // GenShare generates a party's in the shares-to-encryption protocol given the party's secret-key share `sk`, a common
@@ -93,7 +128,7 @@ func NewS2EProtocol(params bfv.Parameters, sigmaSmudging float64) *S2EProtocol {
 func (s2e *S2EProtocol) GenShare(sk *rlwe.SecretKey, crp drlwe.CKSCRP, secretShare *rlwe.AdditiveShare, c0ShareOut *drlwe.CKSShare) {
 	s2e.encoder.ScaleUp(&bfv.PlaintextRingT{Plaintext: &rlwe.Plaintext{Value: &secretShare.Value}}, s2e.tmpPlaintext)
 	s2e.CKSProtocol.GenShare(s2e.zero, sk, &rlwe.Ciphertext{Value: []*ring.Poly{c0ShareOut.Value, (*ring.Poly)(&crp)}}, c0ShareOut)
-	s2e.ringQ.Add(c0ShareOut.Value, s2e.tmpPlaintext.Value, c0ShareOut.Value)
+	s2e.RingQ().Add(c0ShareOut.Value, s2e.tmpPlaintext.Value, c0ShareOut.Value)
 }
 
 // GetEncryption computes the final encryption of the secret-shared message when provided with the aggregation `c0Agg` of the parties'

--- a/dbfv/sharing.go
+++ b/dbfv/sharing.go
@@ -64,8 +64,8 @@ func NewE2SProtocol(params bfv.Parameters, sigmaSmudging float64) *E2SProtocol {
 
 // GenShare generates a party's share in the encryption-to-shares protocol. This share consist in the additive secret-share of the party
 // which is written in secretShareOut and in the public masked-decryption share written in publicShareOut.
-func (e2s *E2SProtocol) GenShare(sk *rlwe.SecretKey, ct *bfv.Ciphertext, secretShareOut *rlwe.AdditiveShare, publicShareOut *drlwe.CKSShare) {
-	e2s.CKSProtocol.GenShare(sk, e2s.zero, ct.Ciphertext, publicShareOut)
+func (e2s *E2SProtocol) GenShare(sk *rlwe.SecretKey, c1 *ring.Poly, secretShareOut *rlwe.AdditiveShare, publicShareOut *drlwe.CKSShare) {
+	e2s.CKSProtocol.GenShare(sk, e2s.zero, c1, publicShareOut)
 	e2s.maskSampler.Read(&secretShareOut.Value)
 	e2s.encoder.ScaleUp(&bfv.PlaintextRingT{Plaintext: &rlwe.Plaintext{Value: &secretShareOut.Value}}, e2s.tmpPlaintext)
 	e2s.RingQ().Sub(publicShareOut.Value, e2s.tmpPlaintext.Value, publicShareOut.Value)
@@ -127,7 +127,7 @@ func (s2e *S2EProtocol) ShallowCopy() *S2EProtocol {
 // polynomial sampled from the CRS `crp` and the party's secret share of the message.
 func (s2e *S2EProtocol) GenShare(sk *rlwe.SecretKey, crp drlwe.CKSCRP, secretShare *rlwe.AdditiveShare, c0ShareOut *drlwe.CKSShare) {
 	s2e.encoder.ScaleUp(&bfv.PlaintextRingT{Plaintext: &rlwe.Plaintext{Value: &secretShare.Value}}, s2e.tmpPlaintext)
-	s2e.CKSProtocol.GenShare(s2e.zero, sk, &rlwe.Ciphertext{Value: []*ring.Poly{c0ShareOut.Value, (*ring.Poly)(&crp)}}, c0ShareOut)
+	s2e.CKSProtocol.GenShare(s2e.zero, sk, (*ring.Poly)(&crp), c0ShareOut)
 	s2e.RingQ().Add(c0ShareOut.Value, s2e.tmpPlaintext.Value, c0ShareOut.Value)
 }
 

--- a/dbfv/transform.go
+++ b/dbfv/transform.go
@@ -89,13 +89,12 @@ func (rfp *MaskedTransformProtocol) SampleCRP(level int, crs utils.PRNG) drlwe.C
 
 // AllocateShare allocates the shares of the PermuteProtocol
 func (rfp *MaskedTransformProtocol) AllocateShare() *MaskedTransformShare {
-	level := rfp.QCount() - 1
-	return &MaskedTransformShare{*rfp.e2s.AllocateShare(level), *rfp.s2e.AllocateShare(level)}
+	return &MaskedTransformShare{*rfp.e2s.AllocateShare(), *rfp.s2e.AllocateShare()}
 }
 
 // GenShares generates the shares of the PermuteProtocol
-func (rfp *MaskedTransformProtocol) GenShares(sk *rlwe.SecretKey, ciphertext *bfv.Ciphertext, crs drlwe.CKSCRP, transform MaskedTransformFunc, shareOut *MaskedTransformShare) {
-	rfp.e2s.GenShare(sk, ciphertext, &rlwe.AdditiveShare{Value: *rfp.tmpMask}, &shareOut.e2sShare)
+func (rfp *MaskedTransformProtocol) GenShares(sk *rlwe.SecretKey, c1 *ring.Poly, crs drlwe.CKSCRP, transform MaskedTransformFunc, shareOut *MaskedTransformShare) {
+	rfp.e2s.GenShare(sk, c1, &rlwe.AdditiveShare{Value: *rfp.tmpMask}, &shareOut.e2sShare)
 	mask := rfp.tmpMask
 	if transform != nil {
 		coeffs := rfp.e2s.encoder.DecodeUintNew(&bfv.PlaintextRingT{Plaintext: &rlwe.Plaintext{Value: mask}})

--- a/dbfv/transform.go
+++ b/dbfv/transform.go
@@ -33,10 +33,10 @@ func (rfp *MaskedTransformProtocol) ShallowCopy() *MaskedTransformProtocol {
 	}
 }
 
-// MaskedTransformFunc is type of functions that can be operated on masked BFV plaintexts as a part of the
+// MaskedTransformFunc represents a user-defined in-place function that can be applied to masked BFV plaintexts, as a part of the
 // Masked Transform Protocol.
-// Function takes as input a vector of integers modulo bfv.Parameters.T() of size bfv.Parameters.N() and maps it
-// to another vector of integers modulo bfv.Parameters.T() of size bfv.Parameters.N().
+// The function is called with a vector of integers modulo bfv.Parameters.T() of size bfv.Parameters.N() as input, and must write
+// its output on the same buffer.
 type MaskedTransformFunc func(coeffs []uint64)
 
 // MaskedTransformShare is a struct storing the decryption and recryption shares.

--- a/dckks/dckks_benchmark_test.go
+++ b/dckks/dckks_benchmark_test.go
@@ -58,7 +58,7 @@ func benchPublicKeyGen(testCtx *testContext, b *testing.B) {
 	p := new(Party)
 	p.CKGProtocol = NewCKGProtocol(params)
 	p.s = sk0Shards[0]
-	p.s1 = p.AllocateShares()
+	p.s1 = p.AllocateShare()
 
 	crp := p.SampleCRP(testCtx.crs)
 
@@ -73,7 +73,7 @@ func benchPublicKeyGen(testCtx *testContext, b *testing.B) {
 	b.Run(testString("PublicKeyGen/Agg/", parties, params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.s1, p.s1, p.s1)
+			p.AggregateShare(p.s1, p.s1, p.s1)
 		}
 	})
 
@@ -95,7 +95,7 @@ func benchRelinKeyGen(testCtx *testContext, b *testing.B) {
 	p := new(Party)
 	p.RKGProtocol = NewRKGProtocol(params)
 	p.sk = sk0Shards[0]
-	p.ephSk, p.share1, p.share2 = p.RKGProtocol.AllocateShares()
+	p.ephSk, p.share1, p.share2 = p.RKGProtocol.AllocateShare()
 
 	crp := p.SampleCRP(testCtx.crs)
 
@@ -109,7 +109,7 @@ func benchRelinKeyGen(testCtx *testContext, b *testing.B) {
 	b.Run(testString("RelinKeyGen/Round1Agg/", parties, params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.share1, p.share1, p.share1)
+			p.AggregateShare(p.share1, p.share1, p.share1)
 		}
 	})
 
@@ -123,7 +123,7 @@ func benchRelinKeyGen(testCtx *testContext, b *testing.B) {
 	b.Run(testString("RelinKeyGen/Round2Agg/", parties, params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.share2, p.share2, p.share2)
+			p.AggregateShare(p.share2, p.share2, p.share2)
 		}
 	})
 
@@ -160,7 +160,7 @@ func benchKeySwitching(testCtx *testContext, b *testing.B) {
 	b.Run(testString("KeySwitching/Agg/", parties, params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.share, p.share, p.share)
+			p.AggregateShare(p.share, p.share, p.share)
 		}
 	})
 
@@ -201,7 +201,7 @@ func benchPublicKeySwitching(testCtx *testContext, b *testing.B) {
 	b.Run(testString("PublicKeySwitching/Agg/", parties, params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.share, p.share, p.share)
+			p.AggregateShare(p.share, p.share, p.share)
 		}
 	})
 
@@ -227,7 +227,7 @@ func benchRotKeyGen(testCtx *testContext, b *testing.B) {
 	p := new(Party)
 	p.RTGProtocol = NewRotKGProtocol(params)
 	p.s = sk0Shards[0]
-	p.share = p.AllocateShares()
+	p.share = p.AllocateShare()
 
 	crp := p.SampleCRP(testCtx.crs)
 
@@ -242,7 +242,7 @@ func benchRotKeyGen(testCtx *testContext, b *testing.B) {
 	b.Run(testString("RotKeyGen/Round1/Agg/", parties, params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.AggregateShares(p.share, p.share, p.share)
+			p.AggregateShare(p.share, p.share, p.share)
 		}
 	})
 
@@ -282,14 +282,14 @@ func benchRefresh(testCtx *testContext, b *testing.B) {
 		b.Run(testString("Refresh/Round1/Gen", parties, params), func(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
-				p.GenShares(p.s, logBound, params.LogSlots(), ciphertext.Value[1], ciphertext.Scale, crp, p.share)
+				p.GenShare(p.s, logBound, params.LogSlots(), ciphertext.Value[1], ciphertext.Scale, crp, p.share)
 			}
 		})
 
 		b.Run(testString("Refresh/Round1/Agg", parties, params), func(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
-				p.Aggregate(p.share, p.share, p.share)
+				p.AggregateShare(p.share, p.share, p.share)
 			}
 		})
 
@@ -330,24 +330,24 @@ func benchMaskedTransform(testCtx *testContext, b *testing.B) {
 
 		crp := p.SampleCRP(params.MaxLevel(), testCtx.crs)
 
-		permute := func(ptIn, ptOut []*ring.Complex) {
-			for i := range ptIn {
-				ptOut[i][0].Mul(ptIn[i][0], ring.NewFloat(0.9238795325112867, logBound))
-				ptOut[i][1].Mul(ptIn[i][1], ring.NewFloat(0.7071067811865476, logBound))
+		permute := func(coeffs []*ring.Complex) {
+			for i := range coeffs {
+				coeffs[i][0].Mul(coeffs[i][0], ring.NewFloat(0.9238795325112867, logBound))
+				coeffs[i][1].Mul(coeffs[i][1], ring.NewFloat(0.7071067811865476, logBound))
 			}
 		}
 
 		b.Run(testString("Refresh&Transform/Round1/Gen", parties, params), func(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
-				p.GenShares(p.s, logBound, params.LogSlots(), ciphertext.Value[1], ciphertext.Scale, crp, permute, p.share)
+				p.GenShare(p.s, logBound, params.LogSlots(), ciphertext.Value[1], ciphertext.Scale, crp, permute, p.share)
 			}
 		})
 
 		b.Run(testString("Refresh&Transform/Round1/Agg", parties, params), func(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
-				p.Aggregate(p.share, p.share, p.share)
+				p.AggregateShare(p.share, p.share, p.share)
 			}
 		})
 

--- a/dckks/dckks_benchmark_test.go
+++ b/dckks/dckks_benchmark_test.go
@@ -153,7 +153,7 @@ func benchKeySwitching(testCtx *testContext, b *testing.B) {
 	b.Run(testString("KeySwitching/Gen/", parties, params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.GenShare(p.s0, p.s1, ciphertext.Ciphertext, p.share)
+			p.GenShare(p.s0, p.s1, ciphertext.Value[1], p.share)
 		}
 	})
 
@@ -167,7 +167,7 @@ func benchKeySwitching(testCtx *testContext, b *testing.B) {
 	b.Run(testString("KeySwitching/KS/", parties, params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.KeySwitch(p.share, ciphertext.Ciphertext, ciphertext.Ciphertext)
+			p.KeySwitch(ciphertext, p.share, ciphertext)
 		}
 	})
 }
@@ -194,7 +194,7 @@ func benchPublicKeySwitching(testCtx *testContext, b *testing.B) {
 	b.Run(testString("PublicKeySwitching/Gen/", parties, params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.GenShare(p.s, pk1, ciphertext.Ciphertext, p.share)
+			p.GenShare(p.s, pk1, ciphertext.Value[1], p.share)
 		}
 	})
 
@@ -208,7 +208,7 @@ func benchPublicKeySwitching(testCtx *testContext, b *testing.B) {
 	b.Run(testString("PublicKeySwitching/KS/", parties, params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.KeySwitch(p.share, ciphertext.Ciphertext, ciphertext.Ciphertext)
+			p.KeySwitch(ciphertext, p.share, ciphertext)
 		}
 	})
 }
@@ -282,7 +282,7 @@ func benchRefresh(testCtx *testContext, b *testing.B) {
 		b.Run(testString("Refresh/Round1/Gen", parties, params), func(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
-				p.GenShares(p.s, logBound, params.LogSlots(), ciphertext, crp, p.share)
+				p.GenShares(p.s, logBound, params.LogSlots(), ciphertext.Value[1], ciphertext.Scale, crp, p.share)
 			}
 		})
 
@@ -340,7 +340,7 @@ func benchMaskedTransform(testCtx *testContext, b *testing.B) {
 		b.Run(testString("Refresh&Transform/Round1/Gen", parties, params), func(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
-				p.GenShares(p.s, logBound, params.LogSlots(), ciphertext, crp, permute, p.share)
+				p.GenShares(p.s, logBound, params.LogSlots(), ciphertext.Value[1], ciphertext.Scale, crp, permute, p.share)
 			}
 		})
 

--- a/dckks/dckks_benchmark_test.go
+++ b/dckks/dckks_benchmark_test.go
@@ -242,7 +242,7 @@ func benchRotKeyGen(testCtx *testContext, b *testing.B) {
 	b.Run(testString("RotKeyGen/Round1/Agg/", parties, params), func(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
-			p.Aggregate(p.share, p.share, p.share)
+			p.AggregateShares(p.share, p.share, p.share)
 		}
 	})
 

--- a/dckks/dckks_test.go
+++ b/dckks/dckks_test.go
@@ -88,7 +88,7 @@ func TestDCKKS(t *testing.T) {
 		testParams = append(ckks.DefaultParams[:4], ckks.DefaultConjugateInvariantParams[:4]...)
 	}
 
-	for _, paramsLiteral := range testParams[:] {
+	for _, paramsLiteral := range testParams {
 
 		params, err := ckks.NewParametersFromLiteral(paramsLiteral)
 		if err != nil {
@@ -548,7 +548,7 @@ func testE2SProtocol(testCtx *testContext, t *testing.T) {
 			P[i].sk = testCtx.sk0Shards[i]
 			P[i].publicShareE2S = P[i].e2s.AllocateShare(minLevel)
 			P[i].publicShareS2E = P[i].s2e.AllocateShare(params.Parameters.MaxLevel())
-			P[i].secretShare = rlwe.NewAdditiveShareBigint(params.Parameters)
+			P[i].secretShare = rlwe.NewAdditiveShareBigint(params.Parameters, params.LogSlots())
 		}
 
 		var wg sync.WaitGroup
@@ -570,10 +570,10 @@ func testE2SProtocol(testCtx *testContext, t *testing.T) {
 		}
 
 		// sum(-M_i) + x
-		P[0].e2s.GetShare(P[0].secretShare, P[0].publicShareE2S, ciphertext, P[0].secretShare)
+		P[0].e2s.GetShare(P[0].secretShare, P[0].publicShareE2S, params.LogSlots(), ciphertext, P[0].secretShare)
 
 		// sum(-M_i) + x + sum(M_i) = x
-		rec := rlwe.NewAdditiveShareBigint(params.Parameters)
+		rec := rlwe.NewAdditiveShareBigint(params.Parameters, params.LogSlots())
 		for _, p := range P {
 			a := rec.Value
 			b := p.secretShare.Value
@@ -594,7 +594,7 @@ func testE2SProtocol(testCtx *testContext, t *testing.T) {
 		wg.Add(parties)
 		for _, p := range P {
 			go func(p Party) {
-				p.s2e.GenShare(p.sk, crp, p.secretShare, p.publicShareS2E)
+				p.s2e.GenShare(p.sk, crp, params.LogSlots(), p.secretShare, p.publicShareS2E)
 				wg.Done()
 			}(p)
 		}

--- a/dckks/dckks_test.go
+++ b/dckks/dckks_test.go
@@ -436,7 +436,7 @@ func testRotKeyGenConjugate(testCtx *testContext, t *testing.T) {
 		for i, p := range pcksParties {
 			p.GenShare(p.s, galEl, crp, p.share)
 			if i > 0 {
-				P0.Aggregate(p.share, P0.share, P0.share)
+				P0.AggregateShares(p.share, P0.share, P0.share)
 			}
 		}
 
@@ -497,7 +497,7 @@ func testRotKeyGenCols(testCtx *testContext, t *testing.T) {
 			for i, p := range pcksParties {
 				p.GenShare(p.s, galEl, crp, p.share)
 				if i > 0 {
-					P0.Aggregate(p.share, P0.share, P0.share)
+					P0.AggregateShares(p.share, P0.share, P0.share)
 				}
 			}
 			P0.GenRotationKey(P0.share, crp, rotKeySet.Keys[galEl])

--- a/dckks/keygen.go
+++ b/dckks/keygen.go
@@ -32,7 +32,7 @@ type RKGProtocol struct {
 // NewRKGProtocol creates a new RKGProtocol object that will be used to generate a collective evaluation-key
 // among j parties in the given context with the given bit-decomposition.
 func NewRKGProtocol(params ckks.Parameters) *RKGProtocol {
-	return &RKGProtocol{*drlwe.NewRKGProtocol(params.Parameters, 0.5)}
+	return &RKGProtocol{*drlwe.NewRKGProtocol(params.Parameters)}
 }
 
 // ShallowCopy creates a shallow copy of RKGProtocol in which all the read-only data-structures are

--- a/dckks/keygen.go
+++ b/dckks/keygen.go
@@ -13,7 +13,6 @@ type CKGProtocol struct {
 
 // NewCKGProtocol creates a new CKGProtocol instance
 func NewCKGProtocol(params ckks.Parameters) *CKGProtocol {
-
 	ckg := new(CKGProtocol)
 	ckg.CKGProtocol = *drlwe.NewCKGProtocol(params.Parameters)
 	return ckg

--- a/dckks/keygen.go
+++ b/dckks/keygen.go
@@ -13,9 +13,14 @@ type CKGProtocol struct {
 
 // NewCKGProtocol creates a new CKGProtocol instance
 func NewCKGProtocol(params ckks.Parameters) *CKGProtocol {
-	ckg := new(CKGProtocol)
-	ckg.CKGProtocol = *drlwe.NewCKGProtocol(params.Parameters)
-	return ckg
+	return &CKGProtocol{*drlwe.NewCKGProtocol(params.Parameters)}
+}
+
+// ShallowCopy creates a shallow copy of CKGProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// CKGProtocol can be used concurrently.
+func (ckg *CKGProtocol) ShallowCopy() *CKGProtocol {
+	return &CKGProtocol{*ckg.CKGProtocol.ShallowCopy()}
 }
 
 // RKGProtocol is the structure storing the parameters and state for a party in the collective relinearization key
@@ -30,6 +35,13 @@ func NewRKGProtocol(params ckks.Parameters) *RKGProtocol {
 	return &RKGProtocol{*drlwe.NewRKGProtocol(params.Parameters, 0.5)}
 }
 
+// ShallowCopy creates a shallow copy of RKGProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// RKGProtocol can be used concurrently.
+func (rkg *RKGProtocol) ShallowCopy() *RKGProtocol {
+	return &RKGProtocol{*rkg.RKGProtocol.ShallowCopy()}
+}
+
 // RTGProtocol is the structure storing the parameters for the collective rotation-keys generation.
 type RTGProtocol struct {
 	drlwe.RTGProtocol
@@ -38,4 +50,11 @@ type RTGProtocol struct {
 // NewRotKGProtocol creates a new rotkg object and will be used to generate collective rotation-keys from a shared secret-key among j parties.
 func NewRotKGProtocol(params ckks.Parameters) (rtg *RTGProtocol) {
 	return &RTGProtocol{*drlwe.NewRTGProtocol(params.Parameters)}
+}
+
+// ShallowCopy creates a shallow copy of RTGProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// RTGProtocol can be used concurrently.
+func (rtg *RTGProtocol) ShallowCopy() *RTGProtocol {
+	return &RTGProtocol{*rtg.RTGProtocol.ShallowCopy()}
 }

--- a/dckks/keyswitch.go
+++ b/dckks/keyswitch.go
@@ -23,6 +23,13 @@ func (cks *CKSProtocol) KeySwitchCKKS(combined *drlwe.CKSShare, ct *ckks.Ciphert
 	cks.CKSProtocol.KeySwitch(combined, ct.Ciphertext, ctOut.Ciphertext)
 }
 
+// ShallowCopy creates a shallow copy of CKSProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// CKSProtocol can be used concurrently.
+func (cks *CKSProtocol) ShallowCopy() *CKSProtocol {
+	return &CKSProtocol{*cks.CKSProtocol.ShallowCopy()}
+}
+
 // PCKSProtocol is the structure storing the parameters for the collective public key-switching.
 type PCKSProtocol struct {
 	drlwe.PCKSProtocol
@@ -38,4 +45,11 @@ func NewPCKSProtocol(params ckks.Parameters, sigmaSmudging float64) *PCKSProtoco
 func (pcks *PCKSProtocol) KeySwitchCKKS(combined *drlwe.PCKSShare, ct, ctOut *ckks.Ciphertext) {
 	pcks.PCKSProtocol.KeySwitch(combined, ct.Ciphertext, ctOut.Ciphertext)
 	ctOut.Scale = ct.Scale
+}
+
+// ShallowCopy creates a shallow copy of PCKSProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// PCKSProtocol can be used concurrently.
+func (pcks *PCKSProtocol) ShallowCopy() *PCKSProtocol {
+	return &PCKSProtocol{*pcks.PCKSProtocol.ShallowCopy()}
 }

--- a/dckks/keyswitch.go
+++ b/dckks/keyswitch.go
@@ -17,10 +17,10 @@ func NewCKSProtocol(params ckks.Parameters, sigmaSmudging float64) (cks *CKSProt
 	return &CKSProtocol{*drlwe.NewCKSProtocol(params.Parameters, sigmaSmudging)}
 }
 
-// KeySwitchCKKS performs the actual keyswitching operation on a ciphertext ct and put the result in ctOut
-func (cks *CKSProtocol) KeySwitchCKKS(combined *drlwe.CKSShare, ct *ckks.Ciphertext, ctOut *ckks.Ciphertext) {
-	ctOut.Scale = ct.Scale
-	cks.CKSProtocol.KeySwitch(combined, ct.Ciphertext, ctOut.Ciphertext)
+// KeySwitch performs the actual keyswitching operation on a ciphertext ct and put the result in ctOut
+func (cks *CKSProtocol) KeySwitch(ctIn *ckks.Ciphertext, combined *drlwe.CKSShare, ctOut *ckks.Ciphertext) {
+	cks.CKSProtocol.KeySwitch(ctIn.Ciphertext, combined, ctOut.Ciphertext)
+	ctOut.Scale = ctIn.Scale
 }
 
 // ShallowCopy creates a shallow copy of CKSProtocol in which all the read-only data-structures are
@@ -41,10 +41,10 @@ func NewPCKSProtocol(params ckks.Parameters, sigmaSmudging float64) *PCKSProtoco
 	return &PCKSProtocol{*drlwe.NewPCKSProtocol(params.Parameters, sigmaSmudging)}
 }
 
-// KeySwitchCKKS performs the actual keyswitching operation on a ciphertext ct and put the result in ctOut
-func (pcks *PCKSProtocol) KeySwitchCKKS(combined *drlwe.PCKSShare, ct, ctOut *ckks.Ciphertext) {
-	pcks.PCKSProtocol.KeySwitch(combined, ct.Ciphertext, ctOut.Ciphertext)
-	ctOut.Scale = ct.Scale
+// KeySwitch performs the actual keyswitching operation on a ciphertext ct and put the result in ctOut.
+func (pcks *PCKSProtocol) KeySwitch(ctIn *ckks.Ciphertext, combined *drlwe.PCKSShare, ctOut *ckks.Ciphertext) {
+	pcks.PCKSProtocol.KeySwitch(ctIn.Ciphertext, combined, ctOut.Ciphertext)
+	ctOut.Scale = ctIn.Scale
 }
 
 // ShallowCopy creates a shallow copy of PCKSProtocol in which all the read-only data-structures are

--- a/dckks/keyswitch.go
+++ b/dckks/keyswitch.go
@@ -10,7 +10,7 @@ type CKSProtocol struct {
 	drlwe.CKSProtocol
 }
 
-// NewCKSProtocol creates a new CKSProtocol that will be used to operate a collective key-switching on a ciphertext encrypted under a collective public-key, whose
+// NewCKSProtocol creates a new CKSProtocol that will be used to perform a collective key-switching on a ciphertext encrypted under a collective public-key, whose
 // secret-shares are distributed among j parties, re-encrypting the ciphertext under another public-key, whose secret-shares are also known to the
 // parties.
 func NewCKSProtocol(params ckks.Parameters, sigmaSmudging float64) (cks *CKSProtocol) {

--- a/dckks/refresh.go
+++ b/dckks/refresh.go
@@ -3,6 +3,7 @@ package dckks
 import (
 	"github.com/ldsec/lattigo/v2/ckks"
 	"github.com/ldsec/lattigo/v2/drlwe"
+	"github.com/ldsec/lattigo/v2/ring"
 	"github.com/ldsec/lattigo/v2/rlwe"
 )
 
@@ -43,8 +44,8 @@ func (rfp *RefreshProtocol) AllocateShare(inputLevel, outputLevel int) *RefreshS
 //
 // The method "GetMinimumLevelForBootstrapping" should be used to get the minimum level at which the refresh can be called while still ensure 128-bits of security, as well as the
 // value for logBound.
-func (rfp *RefreshProtocol) GenShares(sk *rlwe.SecretKey, logBound, logSlots int, ciphertext *ckks.Ciphertext, crs drlwe.CKSCRP, shareOut *RefreshShare) {
-	rfp.MaskedTransformProtocol.GenShares(sk, logBound, logSlots, ciphertext, crs, nil, &shareOut.MaskedTransformShare)
+func (rfp *RefreshProtocol) GenShares(sk *rlwe.SecretKey, logBound, logSlots int, c1 *ring.Poly, scale float64, crs drlwe.CKSCRP, shareOut *RefreshShare) {
+	rfp.MaskedTransformProtocol.GenShares(sk, logBound, logSlots, c1, scale, crs, nil, &shareOut.MaskedTransformShare)
 }
 
 // Aggregate aggregates two parties' shares in the Refresh protocol.
@@ -53,6 +54,6 @@ func (rfp *RefreshProtocol) Aggregate(share1, share2, shareOut *RefreshShare) {
 }
 
 // Finalize applies Decrypt, Recode and Recrypt on the input ciphertext.
-func (rfp *RefreshProtocol) Finalize(ciphertext *ckks.Ciphertext, logSlots int, crs drlwe.CKSCRP, share *RefreshShare, ciphertextOut *ckks.Ciphertext) {
-	rfp.MaskedTransformProtocol.Transform(ciphertext, logSlots, nil, crs, &share.MaskedTransformShare, ciphertextOut)
+func (rfp *RefreshProtocol) Finalize(ctIn *ckks.Ciphertext, logSlots int, crs drlwe.CKSCRP, share *RefreshShare, ctOut *ckks.Ciphertext) {
+	rfp.MaskedTransformProtocol.Transform(ctIn, logSlots, nil, crs, &share.MaskedTransformShare, ctOut)
 }

--- a/dckks/refresh.go
+++ b/dckks/refresh.go
@@ -23,6 +23,13 @@ func NewRefreshProtocol(params ckks.Parameters, precision int, sigmaSmudging flo
 	return
 }
 
+// ShallowCopy creates a shallow copy of RefreshProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// RefreshProtocol can be used concurrently.
+func (rfp *RefreshProtocol) ShallowCopy() *RefreshProtocol {
+	return &RefreshProtocol{*rfp.MaskedTransformProtocol.ShallowCopy()}
+}
+
 // AllocateShare allocates the shares of the PermuteProtocol
 func (rfp *RefreshProtocol) AllocateShare(inputLevel, outputLevel int) *RefreshShare {
 	share := rfp.MaskedTransformProtocol.AllocateShare(inputLevel, outputLevel)

--- a/dckks/sharing.go
+++ b/dckks/sharing.go
@@ -32,7 +32,7 @@ func (e2s *E2SProtocol) ShallowCopy() *E2SProtocol {
 	}
 
 	return &E2SProtocol{
-		CKSProtocol: CKSProtocol{*e2s.CKSProtocol.ShallowCopy()},
+		CKSProtocol: *e2s.CKSProtocol.ShallowCopy(),
 		params:      e2s.params,
 		zero:        e2s.zero,
 		maskBigint:  maskBigint,
@@ -180,7 +180,7 @@ type S2EProtocol struct {
 // S2EProtocol can be used concurrently.
 func (s2e *S2EProtocol) ShallowCopy() *S2EProtocol {
 	return &S2EProtocol{
-		CKSProtocol: CKSProtocol{*s2e.CKSProtocol.ShallowCopy()},
+		CKSProtocol: *s2e.CKSProtocol.ShallowCopy(),
 		params:      s2e.params,
 		tmp:         s2e.params.RingQ().NewPoly(),
 		ssBigint:    make([]*big.Int, s2e.params.N()),

--- a/dckks/sharing.go
+++ b/dckks/sharing.go
@@ -38,7 +38,7 @@ func NewE2SProtocol(params ckks.Parameters, sigmaSmudging float64) *E2SProtocol 
 }
 
 // AllocateShare allocates a share of the E2S protocol
-func (e2s E2SProtocol) AllocateShare(level int) (share *drlwe.CKSShare) {
+func (e2s *E2SProtocol) AllocateShare(level int) (share *drlwe.CKSShare) {
 	share = e2s.CKSProtocol.AllocateShare(level)
 	share.Value.IsNTT = true
 	return

--- a/dckks/transform.go
+++ b/dckks/transform.go
@@ -47,10 +47,10 @@ func (rfp *MaskedTransformProtocol) ShallowCopy() *MaskedTransformProtocol {
 	}
 }
 
-// MaskedTransformFunc is a method template for linear transforms that can be
-// evaluated on a ciphertext during its collective refresh.
-// Function takes as input a vector of *ring.Complex of size ckks.Parameters.Slots() and maps it
-// to another vector *ring.Complex of size ckks.Parameters.Slots().
+// MaskedTransformFunc represents a user-defined in-place function that can be evaluated on masked CKKS plaintexts, as a part of the
+// Masked Transform Protocol.
+// The function is called with a vector of *ring.Complex modulo ckks.Parameters.Slots() as input, and must write
+// its output on the same buffer.
 type MaskedTransformFunc func(coeffs []*ring.Complex)
 
 // MaskedTransformShare is a struct storing the decryption and recryption shares.

--- a/dckks/utils.go
+++ b/dckks/utils.go
@@ -1,11 +1,12 @@
 package dckks
 
 import (
+	"math"
+	"math/bits"
+
 	"github.com/ldsec/lattigo/v2/ckks"
 	"github.com/ldsec/lattigo/v2/ring"
 	"github.com/ldsec/lattigo/v2/rlwe"
-	"math"
-	"math/bits"
 )
 
 // GetMinimumLevelForBootstrapping takes the security parameter lambda, the ciphertext scale, the number of parties and the moduli chain
@@ -34,7 +35,7 @@ func GetMinimumLevelForBootstrapping(lambda int, scale float64, nParties int, mo
 	return minLevel, logBound, true
 }
 
-// NewAdditiveShareBigint instantiate a new additive share struct composed of "n" big.Int elements
+// NewAdditiveShareBigint instantiates a new additive share struct composed of "n" big.Int elements
 func NewAdditiveShareBigint(params ckks.Parameters, logSlots int) *rlwe.AdditiveShareBigint {
 	dslots := 1 << logSlots
 	if params.RingType() == ring.Standard {

--- a/dckks/utils.go
+++ b/dckks/utils.go
@@ -1,6 +1,9 @@
 package dckks
 
 import (
+	"github.com/ldsec/lattigo/v2/ckks"
+	"github.com/ldsec/lattigo/v2/ring"
+	"github.com/ldsec/lattigo/v2/rlwe"
 	"math"
 	"math/bits"
 )
@@ -29,4 +32,13 @@ func GetMinimumLevelForBootstrapping(lambda int, scale float64, nParties int, mo
 	}
 
 	return minLevel, logBound, true
+}
+
+// NewAdditiveShareBigint instantiate a new additive share struct composed of "n" big.Int elements
+func NewAdditiveShareBigint(params ckks.Parameters, logSlots int) *rlwe.AdditiveShareBigint {
+	dslots := 1 << logSlots
+	if params.RingType() == ring.Standard {
+		dslots *= 2
+	}
+	return rlwe.NewAdditiveShareBigint(params.Parameters, dslots)
 }

--- a/drlwe/drlwe_test.go
+++ b/drlwe/drlwe_test.go
@@ -121,7 +121,7 @@ func testPublicKeyGen(testCtx testContext, t *testing.T) {
 		wg.Add(nbParties)
 		for i := range shares {
 			go func(i int) {
-				shares[i] = ckg[i].AllocateShares()
+				shares[i] = ckg[i].AllocateShare()
 				wg.Done()
 			}(i)
 		}
@@ -139,7 +139,7 @@ func testPublicKeyGen(testCtx testContext, t *testing.T) {
 		wg.Wait()
 
 		for i := 1; i < nbParties; i++ {
-			ckg[0].AggregateShares(shares[0], shares[i], shares[0])
+			ckg[0].AggregateShare(shares[0], shares[i], shares[0])
 		}
 
 		pk := rlwe.NewPublicKey(params)
@@ -210,7 +210,7 @@ func testKeySwitching(testCtx testContext, t *testing.T) {
 		wg.Wait()
 
 		for i := 1; i < nbParties; i++ {
-			cks[i].AggregateShares(shares[0], shares[i], shares[0])
+			cks[i].AggregateShare(shares[0], shares[i], shares[0])
 		}
 
 		ksCiphertext := &rlwe.Ciphertext{Value: []*ring.Poly{params.RingQ().NewPoly(), params.RingQ().NewPoly()}}
@@ -273,7 +273,7 @@ func testPublicKeySwitching(testCtx testContext, t *testing.T) {
 		wg.Wait()
 
 		for i := 1; i < nbParties; i++ {
-			pcks[0].AggregateShares(shares[0], shares[i], shares[0])
+			pcks[0].AggregateShare(shares[0], shares[i], shares[0])
 		}
 
 		ksCiphertext := &rlwe.Ciphertext{Value: []*ring.Poly{params.RingQ().NewPoly(), params.RingQ().NewPoly()}}
@@ -322,7 +322,7 @@ func testRelinKeyGen(testCtx testContext, t *testing.T) {
 		wg.Add(nbParties)
 		for i := range rkg {
 			go func(i int) {
-				ephSk[i], share1[i], share2[i] = rkg[i].AllocateShares()
+				ephSk[i], share1[i], share2[i] = rkg[i].AllocateShare()
 				wg.Done()
 			}(i)
 		}
@@ -340,7 +340,7 @@ func testRelinKeyGen(testCtx testContext, t *testing.T) {
 		wg.Wait()
 
 		for i := 1; i < nbParties; i++ {
-			rkg[0].AggregateShares(share1[0], share1[i], share1[0])
+			rkg[0].AggregateShare(share1[0], share1[i], share1[0])
 		}
 
 		wg.Add(nbParties)
@@ -353,7 +353,7 @@ func testRelinKeyGen(testCtx testContext, t *testing.T) {
 		wg.Wait()
 
 		for i := 1; i < nbParties; i++ {
-			rkg[0].AggregateShares(share2[0], share2[i], share2[0])
+			rkg[0].AggregateShare(share2[0], share2[i], share2[0])
 		}
 
 		rlk := rlwe.NewRelinKey(params, 2)
@@ -430,7 +430,7 @@ func testRotKeyGen(testCtx testContext, t *testing.T) {
 		wg.Add(nbParties)
 		for i := range shares {
 			go func(i int) {
-				shares[i] = rtg[i].AllocateShares()
+				shares[i] = rtg[i].AllocateShare()
 				wg.Done()
 			}(i)
 		}
@@ -450,7 +450,7 @@ func testRotKeyGen(testCtx testContext, t *testing.T) {
 		wg.Wait()
 
 		for i := 1; i < nbParties; i++ {
-			rtg[0].AggregateShares(shares[0], shares[i], shares[0])
+			rtg[0].AggregateShare(shares[0], shares[i], shares[0])
 		}
 
 		rotKeySet := rlwe.NewRotationKeySet(params, []uint64{galEl})
@@ -508,7 +508,7 @@ func testMarshalling(testCtx testContext, t *testing.T) {
 
 	t.Run(testString(params, "Marshalling/CKG"), func(t *testing.T) {
 		ckg := NewCKGProtocol(testCtx.params)
-		KeyGenShareBefore := ckg.AllocateShares()
+		KeyGenShareBefore := ckg.AllocateShare()
 		crs := ckg.SampleCRP(testCtx.crs)
 
 		ckg.GenShare(testCtx.skShares[0], crs, KeyGenShareBefore)
@@ -588,7 +588,7 @@ func testMarshalling(testCtx testContext, t *testing.T) {
 
 		RKGProtocol := NewRKGProtocol(params, rlwe.DefaultSigma)
 
-		ephSk0, share10, _ := RKGProtocol.AllocateShares()
+		ephSk0, share10, _ := RKGProtocol.AllocateShare()
 
 		crp := RKGProtocol.SampleCRP(testCtx.crs)
 
@@ -626,7 +626,7 @@ func testMarshalling(testCtx testContext, t *testing.T) {
 		galEl := testCtx.params.GaloisElementForColumnRotationBy(64)
 
 		rtg := NewRTGProtocol(testCtx.params)
-		rtgShare := rtg.AllocateShares()
+		rtgShare := rtg.AllocateShare()
 
 		crp := rtg.SampleCRP(testCtx.crs)
 

--- a/drlwe/drlwe_test.go
+++ b/drlwe/drlwe_test.go
@@ -306,7 +306,7 @@ func testRelinKeyGen(testCtx testContext, t *testing.T) {
 
 		for i := range rkg {
 			if i == 0 {
-				rkg[i] = NewRKGProtocol(params, rlwe.DefaultSigma)
+				rkg[i] = NewRKGProtocol(params)
 			} else {
 				rkg[i] = rkg[0].ShallowCopy()
 			}
@@ -586,7 +586,7 @@ func testMarshalling(testCtx testContext, t *testing.T) {
 
 		//check RTGShare
 
-		RKGProtocol := NewRKGProtocol(params, rlwe.DefaultSigma)
+		RKGProtocol := NewRKGProtocol(params)
 
 		ephSk0, share10, _ := RKGProtocol.AllocateShare()
 

--- a/drlwe/keygen_cpk.go
+++ b/drlwe/keygen_cpk.go
@@ -9,9 +9,9 @@ import (
 
 // CollectivePublicKeyGenerator is an interface describing the local steps of a generic RLWE CKG protocol.
 type CollectivePublicKeyGenerator interface {
-	AllocateShares() *CKGShare
+	AllocateShare() *CKGShare
 	GenShare(sk *rlwe.SecretKey, crp CKGCRP, shareOut *CKGShare)
-	AggregateShares(share1, share2, shareOut *CKGShare)
+	AggregateShare(share1, share2, shareOut *CKGShare)
 	GenPublicKey(aggregatedShare *CKGShare, crp CKGCRP, pubkey *rlwe.PublicKey)
 }
 
@@ -69,8 +69,8 @@ func NewCKGProtocol(params rlwe.Parameters) *CKGProtocol {
 	return ckg
 }
 
-// AllocateShares allocates the share of the CKG protocol.
-func (ckg *CKGProtocol) AllocateShares() *CKGShare {
+// AllocateShare allocates the share of the CKG protocol.
+func (ckg *CKGProtocol) AllocateShare() *CKGShare {
 	return &CKGShare{ckg.params.RingQP().NewPoly()}
 }
 
@@ -98,8 +98,8 @@ func (ckg *CKGProtocol) GenShare(sk *rlwe.SecretKey, crp CKGCRP, shareOut *CKGSh
 	ringQP.MulCoeffsMontgomeryAndSubLvl(levelQ, levelP, sk.Value, rlwe.PolyQP(crp), shareOut.Value)
 }
 
-// AggregateShares aggregates a new share to the aggregate key
-func (ckg *CKGProtocol) AggregateShares(share1, share2, shareOut *CKGShare) {
+// AggregateShare aggregates a new share to the aggregate key
+func (ckg *CKGProtocol) AggregateShare(share1, share2, shareOut *CKGShare) {
 	ckg.params.RingQP().AddLvl(ckg.params.QCount()-1, ckg.params.PCount()-1, share1.Value, share2.Value, shareOut.Value)
 }
 

--- a/drlwe/keygen_cpk.go
+++ b/drlwe/keygen_cpk.go
@@ -21,6 +21,18 @@ type CKGProtocol struct {
 	gaussianSamplerQ *ring.GaussianSampler
 }
 
+// ShallowCopy creates a shallow copy of CKGProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// CKGProtocol can be used concurrently.
+func (ckg *CKGProtocol) ShallowCopy() *CKGProtocol {
+	prng, err := utils.NewPRNG()
+	if err != nil {
+		panic(err)
+	}
+
+	return &CKGProtocol{ckg.params, ring.NewGaussianSampler(prng, ckg.params.RingQ(), ckg.params.Sigma(), int(6*ckg.params.Sigma()))}
+}
+
 // CKGShare is a struct storing the CKG protocol's share.
 type CKGShare struct {
 	Value rlwe.PolyQP
@@ -53,7 +65,7 @@ func NewCKGProtocol(params rlwe.Parameters) *CKGProtocol {
 	if err != nil {
 		panic(err)
 	}
-	ckg.gaussianSamplerQ = ring.NewGaussianSampler(prng, ckg.params.RingQ(), params.Sigma(), int(6*params.Sigma()))
+	ckg.gaussianSamplerQ = ring.NewGaussianSampler(prng, params.RingQ(), params.Sigma(), int(6*params.Sigma()))
 	return ckg
 }
 

--- a/drlwe/keygen_relin.go
+++ b/drlwe/keygen_relin.go
@@ -11,10 +11,10 @@ import (
 
 // RelinearizationKeyGenerator is an interface describing the local steps of a generic RLWE RKG protocol
 type RelinearizationKeyGenerator interface {
-	AllocateShares() (ephKey *rlwe.SecretKey, r1 *RKGShare, r2 *RKGShare)
+	AllocateShare() (ephKey *rlwe.SecretKey, r1 *RKGShare, r2 *RKGShare)
 	GenShareRoundOne(sk *rlwe.SecretKey, crp RKGCRP, ephKeyOut *rlwe.SecretKey, shareOut *RKGShare)
 	GenShareRoundTwo(ephSk, sk *rlwe.SecretKey, round1 *RKGShare, shareOut *RKGShare)
-	AggregateShares(share1, share2, shareOut *RKGShare)
+	AggregateShare(share1, share2, shareOut *RKGShare)
 	GenRelinearizationKey(round1 *RKGShare, round2 *RKGShare, relinKeyOut *rlwe.RelinearizationKey)
 }
 
@@ -80,8 +80,8 @@ func NewRKGProtocol(params rlwe.Parameters, ephSkPr float64) *RKGProtocol {
 	return rkg
 }
 
-// AllocateShares allocates the shares of the EKG protocol.
-func (ekg *RKGProtocol) AllocateShares() (ephSk *rlwe.SecretKey, r1 *RKGShare, r2 *RKGShare) {
+// AllocateShare allocates the share of the EKG protocol.
+func (ekg *RKGProtocol) AllocateShare() (ephSk *rlwe.SecretKey, r1 *RKGShare, r2 *RKGShare) {
 	ephSk = rlwe.NewSecretKey(ekg.params)
 	r1, r2 = new(RKGShare), new(RKGShare)
 	r1.Value = make([][2]rlwe.PolyQP, ekg.params.Beta())
@@ -206,8 +206,8 @@ func (ekg *RKGProtocol) GenShareRoundTwo(ephSk, sk *rlwe.SecretKey, round1 *RKGS
 
 }
 
-// AggregateShares combines two RKG shares into a single one
-func (ekg *RKGProtocol) AggregateShares(share1, share2, shareOut *RKGShare) {
+// AggregateShare combines two RKG shares into a single one
+func (ekg *RKGProtocol) AggregateShare(share1, share2, shareOut *RKGShare) {
 	ringQP, levelQ, levelP := ekg.params.RingQP(), ekg.params.QCount()-1, ekg.params.PCount()-1
 	for i := 0; i < ekg.params.Beta(); i++ {
 		ringQP.AddLvl(levelQ, levelP, share1.Value[i][0], share2.Value[i][0], shareOut.Value[i][0])

--- a/drlwe/keygen_relin.go
+++ b/drlwe/keygen_relin.go
@@ -61,10 +61,10 @@ type RKGShare struct {
 type RKGCRP []rlwe.PolyQP
 
 // NewRKGProtocol creates a new RKG protocol struct
-func NewRKGProtocol(params rlwe.Parameters, ephSkPr float64) *RKGProtocol {
+func NewRKGProtocol(params rlwe.Parameters) *RKGProtocol {
 	rkg := new(RKGProtocol)
 	rkg.params = params
-	rkg.ephSkPr = ephSkPr
+	rkg.ephSkPr = 0.5 // TODO: read from Params
 
 	var err error
 	prng, err := utils.NewPRNG()
@@ -74,7 +74,7 @@ func NewRKGProtocol(params rlwe.Parameters, ephSkPr float64) *RKGProtocol {
 
 	rkg.pBigInt = params.PBigInt()
 	rkg.gaussianSamplerQ = ring.NewGaussianSampler(prng, params.RingQ(), params.Sigma(), int(6*params.Sigma()))
-	rkg.ternarySamplerQ = ring.NewTernarySampler(prng, params.RingQ(), ephSkPr, false)
+	rkg.ternarySamplerQ = ring.NewTernarySampler(prng, params.RingQ(), rkg.ephSkPr, false)
 	rkg.tmpPoly1 = params.RingQP().NewPoly()
 	rkg.tmpPoly2 = params.RingQP().NewPoly()
 	return rkg

--- a/drlwe/keygen_relin.go
+++ b/drlwe/keygen_relin.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ldsec/lattigo/v2/utils"
 )
 
-// RelinearizationKeyGenerator is an interface describing the local steps of a generic RLWE RKG protocol
+// RelinearizationKeyGenerator is an interface describing the local steps of a generic RLWE RKG protocol.
 type RelinearizationKeyGenerator interface {
 	AllocateShare() (ephKey *rlwe.SecretKey, r1 *RKGShare, r2 *RKGShare)
 	GenShareRoundOne(sk *rlwe.SecretKey, crp RKGCRP, ephKeyOut *rlwe.SecretKey, shareOut *RKGShare)
@@ -52,7 +52,7 @@ func (ekg *RKGProtocol) ShallowCopy() *RKGProtocol {
 	}
 }
 
-// RKGShare is a share in the RKG protocol
+// RKGShare is a share in the RKG protocol.
 type RKGShare struct {
 	Value [][2]rlwe.PolyQP
 }
@@ -60,7 +60,7 @@ type RKGShare struct {
 // RKGCRP is a type for common reference polynomials in the RKG protocol.
 type RKGCRP []rlwe.PolyQP
 
-// NewRKGProtocol creates a new RKG protocol struct
+// NewRKGProtocol creates a new RKG protocol struct.
 func NewRKGProtocol(params rlwe.Parameters) *RKGProtocol {
 	rkg := new(RKGProtocol)
 	rkg.params = params
@@ -182,7 +182,7 @@ func (ekg *RKGProtocol) GenShareRoundTwo(ephSk, sk *rlwe.SecretKey, round1 *RKGS
 	ringQP.SubLvl(levelQ, levelP, ephSk.Value, sk.Value, ekg.tmpPoly1)
 
 	// Each sample is of the form [-u*a_i + s*w_i + e_i]
-	// So for each element of the base decomposition w_i :
+	// So for each element of the base decomposition w_i:
 	for i := 0; i < ekg.params.Beta(); i++ {
 
 		// Computes [(sum samples)*sk + e_1i, sk*a + e_2i]
@@ -206,7 +206,7 @@ func (ekg *RKGProtocol) GenShareRoundTwo(ephSk, sk *rlwe.SecretKey, round1 *RKGS
 
 }
 
-// AggregateShare combines two RKG shares into a single one
+// AggregateShare combines two RKG shares into a single one.
 func (ekg *RKGProtocol) AggregateShare(share1, share2, shareOut *RKGShare) {
 	ringQP, levelQ, levelP := ekg.params.RingQP(), ekg.params.QCount()-1, ekg.params.PCount()-1
 	for i := 0; i < ekg.params.Beta(); i++ {
@@ -215,7 +215,7 @@ func (ekg *RKGProtocol) AggregateShare(share1, share2, shareOut *RKGShare) {
 	}
 }
 
-// GenRelinearizationKey computes the generated RLK from the public shares and write the result in evalKeyOut
+// GenRelinearizationKey computes the generated RLK from the public shares and write the result in evalKeyOut.
 func (ekg *RKGProtocol) GenRelinearizationKey(round1 *RKGShare, round2 *RKGShare, evalKeyOut *rlwe.RelinearizationKey) {
 	ringQP, levelQ, levelP := ekg.params.RingQP(), ekg.params.QCount()-1, ekg.params.PCount()-1
 	for i := 0; i < ekg.params.Beta(); i++ {
@@ -235,7 +235,7 @@ func (share *RKGShare) MarshalBinary() ([]byte, error) {
 	}
 	data[0] = uint8(len(share.Value))
 
-	//write all of our rings in the data.
+	//write all of our rings in the data
 	//write all the polys
 	ptr := 1
 	var inc int

--- a/drlwe/keygen_rot.go
+++ b/drlwe/keygen_rot.go
@@ -12,7 +12,7 @@ import (
 type RotationKeyGenerator interface {
 	AllocateShares() (rtgShare *RTGShare)
 	GenShare(sk *rlwe.SecretKey, galEl uint64, crp RTGCRP, shareOut *RTGShare)
-	Aggregate(share1, share2, shareOut *RTGShare)
+	AggregateShares(share1, share2, shareOut *RTGShare)
 	GenRotationKey(share *RTGShare, crp RTGCRP, rotKey *rlwe.SwitchingKey)
 }
 
@@ -141,8 +141,8 @@ func (rtg *RTGProtocol) GenShare(sk *rlwe.SecretKey, galEl uint64, crp RTGCRP, s
 	}
 }
 
-// Aggregate aggregates two shares in the Rotation Key Generation protocol
-func (rtg *RTGProtocol) Aggregate(share1, share2, shareOut *RTGShare) {
+// AggregateShares aggregates two shares in the Rotation Key Generation protocol
+func (rtg *RTGProtocol) AggregateShares(share1, share2, shareOut *RTGShare) {
 	ringQP, levelQ, levelP := rtg.params.RingQP(), rtg.params.QCount()-1, rtg.params.PCount()-1
 	for i := 0; i < rtg.params.Beta(); i++ {
 		ringQP.AddLvl(levelQ, levelP, share1.Value[i], share2.Value[i], shareOut.Value[i])

--- a/drlwe/keygen_rot.go
+++ b/drlwe/keygen_rot.go
@@ -10,9 +10,9 @@ import (
 
 // RotationKeyGenerator is an interface for the local operation in the generation of rotation keys
 type RotationKeyGenerator interface {
-	AllocateShares() (rtgShare *RTGShare)
+	AllocateShare() (rtgShare *RTGShare)
 	GenShare(sk *rlwe.SecretKey, galEl uint64, crp RTGCRP, shareOut *RTGShare)
-	AggregateShares(share1, share2, shareOut *RTGShare)
+	AggregateShare(share1, share2, shareOut *RTGShare)
 	GenRotationKey(share *RTGShare, crp RTGCRP, rotKey *rlwe.SwitchingKey)
 }
 
@@ -66,8 +66,8 @@ func NewRTGProtocol(params rlwe.Parameters) *RTGProtocol {
 	return rtg
 }
 
-// AllocateShares allocates a party's share in the RTG protocol
-func (rtg *RTGProtocol) AllocateShares() (rtgShare *RTGShare) {
+// AllocateShare allocates a party's share in the RTG protocol
+func (rtg *RTGProtocol) AllocateShare() (rtgShare *RTGShare) {
 	rtgShare = new(RTGShare)
 	rtgShare.Value = make([]rlwe.PolyQP, rtg.params.Beta())
 	for i := range rtgShare.Value {
@@ -141,8 +141,8 @@ func (rtg *RTGProtocol) GenShare(sk *rlwe.SecretKey, galEl uint64, crp RTGCRP, s
 	}
 }
 
-// AggregateShares aggregates two shares in the Rotation Key Generation protocol
-func (rtg *RTGProtocol) AggregateShares(share1, share2, shareOut *RTGShare) {
+// AggregateShare aggregates two share in the Rotation Key Generation protocol
+func (rtg *RTGProtocol) AggregateShare(share1, share2, shareOut *RTGShare) {
 	ringQP, levelQ, levelP := rtg.params.RingQP(), rtg.params.QCount()-1, rtg.params.PCount()-1
 	for i := 0; i < rtg.params.Beta(); i++ {
 		ringQP.AddLvl(levelQ, levelP, share1.Value[i], share2.Value[i], shareOut.Value[i])

--- a/drlwe/keygen_rot.go
+++ b/drlwe/keygen_rot.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ldsec/lattigo/v2/utils"
 )
 
-// RotationKeyGenerator is an interface for the local operation in the generation of rotation keys
+// RotationKeyGenerator is an interface for the local operation in the generation of rotation keys.
 type RotationKeyGenerator interface {
 	AllocateShare() (rtgShare *RTGShare)
 	GenShare(sk *rlwe.SecretKey, galEl uint64, crp RTGCRP, shareOut *RTGShare)
@@ -16,7 +16,7 @@ type RotationKeyGenerator interface {
 	GenRotationKey(share *RTGShare, crp RTGCRP, rotKey *rlwe.SwitchingKey)
 }
 
-// RTGShare is represent a Party's share in the RTG protocol
+// RTGShare is represent a Party's share in the RTG protocol.
 type RTGShare struct {
 	Value []rlwe.PolyQP
 }
@@ -51,7 +51,7 @@ func (rtg *RTGProtocol) ShallowCopy() *RTGProtocol {
 	}
 }
 
-// NewRTGProtocol creates a RTGProtocol instance
+// NewRTGProtocol creates a RTGProtocol instance.
 func NewRTGProtocol(params rlwe.Parameters) *RTGProtocol {
 	rtg := new(RTGProtocol)
 	rtg.params = params
@@ -66,7 +66,7 @@ func NewRTGProtocol(params rlwe.Parameters) *RTGProtocol {
 	return rtg
 }
 
-// AllocateShare allocates a party's share in the RTG protocol
+// AllocateShare allocates a party's share in the RTG protocol.
 func (rtg *RTGProtocol) AllocateShare() (rtgShare *RTGShare) {
 	rtgShare = new(RTGShare)
 	rtgShare.Value = make([]rlwe.PolyQP, rtg.params.Beta())
@@ -88,7 +88,7 @@ func (rtg *RTGProtocol) SampleCRP(crs CRS) RTGCRP {
 	return RTGCRP(crp)
 }
 
-// GenShare generates a party's share in the RTG protocol
+// GenShare generates a party's share in the RTG protocol.
 func (rtg *RTGProtocol) GenShare(sk *rlwe.SecretKey, galEl uint64, crp RTGCRP, shareOut *RTGShare) {
 
 	ringQ := rtg.params.RingQ()
@@ -141,7 +141,7 @@ func (rtg *RTGProtocol) GenShare(sk *rlwe.SecretKey, galEl uint64, crp RTGCRP, s
 	}
 }
 
-// AggregateShare aggregates two share in the Rotation Key Generation protocol
+// AggregateShare aggregates two share in the Rotation Key Generation protocol.
 func (rtg *RTGProtocol) AggregateShare(share1, share2, shareOut *RTGShare) {
 	ringQP, levelQ, levelP := rtg.params.RingQP(), rtg.params.QCount()-1, rtg.params.PCount()-1
 	for i := 0; i < rtg.params.Beta(); i++ {

--- a/drlwe/keygen_rot.go
+++ b/drlwe/keygen_rot.go
@@ -32,6 +32,25 @@ type RTGProtocol struct {
 	gaussianSamplerQ *ring.GaussianSampler
 }
 
+// ShallowCopy creates a shallow copy of RTGProtocol in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// RTGProtocol can be used concurrently.
+func (rtg *RTGProtocol) ShallowCopy() *RTGProtocol {
+	prng, err := utils.NewPRNG()
+	if err != nil {
+		panic(err)
+	}
+
+	params := rtg.params
+
+	return &RTGProtocol{
+		params:           rtg.params,
+		tmpPoly0:         params.RingQP().NewPoly(),
+		tmpPoly1:         params.RingQP().NewPoly(),
+		gaussianSamplerQ: ring.NewGaussianSampler(prng, params.RingQ(), params.Sigma(), int(6*params.Sigma())),
+	}
+}
+
 // NewRTGProtocol creates a RTGProtocol instance
 func NewRTGProtocol(params rlwe.Parameters) *RTGProtocol {
 	rtg := new(RTGProtocol)

--- a/drlwe/keyswitch_pk.go
+++ b/drlwe/keyswitch_pk.go
@@ -75,7 +75,7 @@ func NewPCKSProtocol(params rlwe.Parameters, sigmaSmudging float64) (pcks *PCKSP
 	return pcks
 }
 
-// AllocateShare allocates the shares of the PCKS protocol
+// AllocateShare allocates the shares of the PCKS protocol.
 func (pcks *PCKSProtocol) AllocateShare(levelQ int) (s *PCKSShare) {
 	return &PCKSShare{[2]*ring.Poly{pcks.params.RingQ().NewPolyLvl(levelQ), pcks.params.RingQ().NewPolyLvl(levelQ)}}
 }

--- a/drlwe/keyswitch_sk.go
+++ b/drlwe/keyswitch_sk.go
@@ -63,7 +63,7 @@ func (ckss *CKSShare) UnmarshalBinary(data []byte) (err error) {
 	return ckss.Value.UnmarshalBinary(data)
 }
 
-// NewCKSProtocol creates a new CKSProtocol that will be used to operate a collective key-switching on a ciphertext encrypted under a collective public-key, whose
+// NewCKSProtocol creates a new CKSProtocol that will be used to perform a collective key-switching on a ciphertext encrypted under a collective public-key, whose
 // secret-shares are distributed among j parties, re-encrypting the ciphertext under another public-key, whose secret-shares are also known to the
 // parties.
 func NewCKSProtocol(params rlwe.Parameters, sigmaSmudging float64) *CKSProtocol {

--- a/drlwe/keyswitch_sk.go
+++ b/drlwe/keyswitch_sk.go
@@ -10,7 +10,7 @@ import (
 type KeySwitchingProtocol interface {
 	AllocateShare(level int) *CKSShare
 	GenShare(skInput, skOutput *rlwe.SecretKey, c1 *ring.Poly, shareOut *CKSShare)
-	AggregateShares(share1, share2, shareOut *CKSShare)
+	AggregateShare(share1, share2, shareOut *CKSShare)
 	KeySwitch(ctIn *rlwe.Ciphertext, combined *CKSShare, ctOut *rlwe.Ciphertext)
 }
 
@@ -95,8 +95,8 @@ func (cks *CKSProtocol) SampleCRP(level int, crs CRS) CKSCRP {
 }
 
 // GenShare computes a party's share in the CKS protocol.
-// c1 = rlwe.Ciphertext.Value[1]
-// NTT flag for ct.Value[1] is expected to be set correctly
+// ct1 is the degree 1 element of the rlwe.Ciphertext to keyswitch, i.e. ct1 = rlwe.Ciphertext.Value[1].
+// NTT flag for ct1 is expected to be set correctly.
 func (cks *CKSProtocol) GenShare(skInput, skOutput *rlwe.SecretKey, c1 *ring.Poly, shareOut *CKSShare) {
 
 	ringQ := cks.params.RingQ()
@@ -158,10 +158,10 @@ func (cks *CKSProtocol) GenShare(skInput, skOutput *rlwe.SecretKey, c1 *ring.Pol
 	shareOut.Value.Coeffs = shareOut.Value.Coeffs[:levelQ+1]
 }
 
-// AggregateShares is the second part of the unique round of the CKSProtocol protocol. Upon receiving the j-1 elements each party computes :
+// AggregateShare is the second part of the unique round of the CKSProtocol protocol. Upon receiving the j-1 elements each party computes :
 //
 // [ctx[0] + sum((skInput_i - skOutput_i) * ctx[0] + e_i), ctx[1]]
-func (cks *CKSProtocol) AggregateShares(share1, share2, shareOut *CKSShare) {
+func (cks *CKSProtocol) AggregateShare(share1, share2, shareOut *CKSShare) {
 	cks.params.RingQ().AddLvl(share1.Value.Level(), share1.Value, share2.Value, shareOut.Value)
 }
 

--- a/examples/dbfv/pir/main.go
+++ b/examples/dbfv/pir/main.go
@@ -213,7 +213,7 @@ func cksphase(params bfv.Parameters, P []*party, result *bfv.Ciphertext) *bfv.Ci
 	encOut := bfv.NewCiphertext(params, 1)
 	elapsedCKSCloud = runTimed(func() {
 		for _, pi := range P {
-			cks.AggregateShares(pi.cksShare, cksCombined, cksCombined)
+			cks.AggregateShare(pi.cksShare, cksCombined, cksCombined)
 		}
 		cks.KeySwitch(result, cksCombined, encOut)
 	})
@@ -251,9 +251,9 @@ func ckgphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.PublicKey
 
 	ckg := dbfv.NewCKGProtocol(params) // Public key generation
 
-	ckgCombined := ckg.AllocateShares()
+	ckgCombined := ckg.AllocateShare()
 	for _, pi := range P {
-		pi.ckgShare = ckg.AllocateShares()
+		pi.ckgShare = ckg.AllocateShare()
 	}
 
 	crp := ckg.SampleCRP(crs)
@@ -268,7 +268,7 @@ func ckgphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.PublicKey
 
 	elapsedCKGCloud = runTimed(func() {
 		for _, pi := range P {
-			ckg.AggregateShares(pi.ckgShare, ckgCombined, ckgCombined)
+			ckg.AggregateShare(pi.ckgShare, ckgCombined, ckgCombined)
 		}
 		ckg.GenPublicKey(ckgCombined, crp, pk)
 	})
@@ -285,10 +285,10 @@ func rkgphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.Relineari
 
 	rkg := dbfv.NewRKGProtocol(params) // Relineariation key generation
 
-	_, rkgCombined1, rkgCombined2 := rkg.AllocateShares()
+	_, rkgCombined1, rkgCombined2 := rkg.AllocateShare()
 
 	for _, pi := range P {
-		pi.rlkEphemSk, pi.rkgShareOne, pi.rkgShareTwo = rkg.AllocateShares()
+		pi.rlkEphemSk, pi.rkgShareOne, pi.rkgShareTwo = rkg.AllocateShare()
 	}
 
 	crp := rkg.SampleCRP(crs)
@@ -301,7 +301,7 @@ func rkgphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.Relineari
 
 	elapsedRKGCloud = runTimed(func() {
 		for _, pi := range P {
-			rkg.AggregateShares(pi.rkgShareOne, rkgCombined1, rkgCombined1)
+			rkg.AggregateShare(pi.rkgShareOne, rkgCombined1, rkgCombined1)
 		}
 	})
 
@@ -314,7 +314,7 @@ func rkgphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.Relineari
 	rlk := bfv.NewRelinearizationKey(params, 1)
 	elapsedRKGCloud += runTimed(func() {
 		for _, pi := range P {
-			rkg.AggregateShares(pi.rkgShareTwo, rkgCombined2, rkgCombined2)
+			rkg.AggregateShare(pi.rkgShareTwo, rkgCombined2, rkgCombined2)
 		}
 		rkg.GenRelinearizationKey(rkgCombined1, rkgCombined2, rlk)
 	})
@@ -333,7 +333,7 @@ func rtkphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.RotationK
 	rtg := dbfv.NewRotKGProtocol(params) // Rotation keys generation
 
 	for _, pi := range P {
-		pi.rtgShare = rtg.AllocateShares()
+		pi.rtgShare = rtg.AllocateShare()
 	}
 
 	galEls := params.GaloisElementsForRowInnerSum()
@@ -341,7 +341,7 @@ func rtkphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.RotationK
 
 	for _, galEl := range galEls {
 
-		rtgShareCombined := rtg.AllocateShares()
+		rtgShareCombined := rtg.AllocateShare()
 
 		crp := rtg.SampleCRP(crs)
 
@@ -353,7 +353,7 @@ func rtkphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.RotationK
 
 		elapsedRTGCloud += runTimed(func() {
 			for _, pi := range P {
-				rtg.AggregateShares(pi.rtgShare, rtgShareCombined, rtgShareCombined)
+				rtg.AggregateShare(pi.rtgShare, rtgShareCombined, rtgShareCombined)
 			}
 			rtg.GenRotationKey(rtgShareCombined, crp, rotKeySet.Keys[galEl])
 		})

--- a/examples/dbfv/pir/main.go
+++ b/examples/dbfv/pir/main.go
@@ -199,14 +199,14 @@ func cksphase(params bfv.Parameters, P []*party, result *bfv.Ciphertext) *bfv.Ci
 	cks := dbfv.NewCKSProtocol(params, 3.19) // Collective public-key re-encryption
 
 	for _, pi := range P {
-		pi.cksShare = cks.AllocateShareBFV()
+		pi.cksShare = cks.AllocateShare()
 	}
 
 	zero := bfv.NewSecretKey(params)
-	cksCombined := cks.AllocateShareBFV()
+	cksCombined := cks.AllocateShare()
 	elapsedPCKSParty = runTimedParty(func() {
 		for _, pi := range P[1:] {
-			cks.GenShare(pi.sk, zero, result.Ciphertext, pi.cksShare)
+			cks.GenShare(pi.sk, zero, result.Value[1], pi.cksShare)
 		}
 	}, len(P)-1)
 
@@ -215,7 +215,7 @@ func cksphase(params bfv.Parameters, P []*party, result *bfv.Ciphertext) *bfv.Ci
 		for _, pi := range P {
 			cks.AggregateShares(pi.cksShare, cksCombined, cksCombined)
 		}
-		cks.KeySwitch(cksCombined, result.Ciphertext, encOut.Ciphertext)
+		cks.KeySwitch(result, cksCombined, encOut)
 	})
 	l.Printf("\tdone (cloud: %s, party: %s)\n", elapsedCKSCloud, elapsedPCKSParty)
 

--- a/examples/dbfv/pir/main.go
+++ b/examples/dbfv/pir/main.go
@@ -353,7 +353,7 @@ func rtkphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.RotationK
 
 		elapsedRTGCloud += runTimed(func() {
 			for _, pi := range P {
-				rtg.Aggregate(pi.rtgShare, rtgShareCombined, rtgShareCombined)
+				rtg.AggregateShares(pi.rtgShare, rtgShareCombined, rtgShareCombined)
 			}
 			rtg.GenRotationKey(rtgShareCombined, crp, rotKeySet.Keys[galEl])
 		})

--- a/examples/dbfv/psi/main.go
+++ b/examples/dbfv/psi/main.go
@@ -311,7 +311,7 @@ func pcksPhase(params bfv.Parameters, tpk *rlwe.PublicKey, encRes *bfv.Ciphertex
 	encOut = bfv.NewCiphertext(params, 1)
 	elapsedPCKSCloud = runTimed(func() {
 		for _, pi := range P {
-			pcks.AggregateShares(pi.pcksShare, pcksCombined, pcksCombined)
+			pcks.AggregateShare(pi.pcksShare, pcksCombined, pcksCombined)
 		}
 		pcks.KeySwitch(encRes, pcksCombined, encOut)
 
@@ -328,10 +328,10 @@ func rkgphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.Relineari
 	l.Println("> RKG Phase")
 
 	rkg := dbfv.NewRKGProtocol(params) // Relineariation key generation
-	_, rkgCombined1, rkgCombined2 := rkg.AllocateShares()
+	_, rkgCombined1, rkgCombined2 := rkg.AllocateShare()
 
 	for _, pi := range P {
-		pi.rlkEphemSk, pi.rkgShareOne, pi.rkgShareTwo = rkg.AllocateShares()
+		pi.rlkEphemSk, pi.rkgShareOne, pi.rkgShareTwo = rkg.AllocateShare()
 	}
 
 	crp := rkg.SampleCRP(crs)
@@ -344,7 +344,7 @@ func rkgphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.Relineari
 
 	elapsedRKGCloud = runTimed(func() {
 		for _, pi := range P {
-			rkg.AggregateShares(pi.rkgShareOne, rkgCombined1, rkgCombined1)
+			rkg.AggregateShare(pi.rkgShareOne, rkgCombined1, rkgCombined1)
 		}
 	})
 
@@ -357,7 +357,7 @@ func rkgphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.Relineari
 	rlk := bfv.NewRelinearizationKey(params, 1)
 	elapsedRKGCloud += runTimed(func() {
 		for _, pi := range P {
-			rkg.AggregateShares(pi.rkgShareTwo, rkgCombined2, rkgCombined2)
+			rkg.AggregateShare(pi.rkgShareTwo, rkgCombined2, rkgCombined2)
 		}
 		rkg.GenRelinearizationKey(rkgCombined1, rkgCombined2, rlk)
 	})
@@ -374,9 +374,9 @@ func ckgphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.PublicKey
 	l.Println("> CKG Phase")
 
 	ckg := dbfv.NewCKGProtocol(params) // Public key generation
-	ckgCombined := ckg.AllocateShares()
+	ckgCombined := ckg.AllocateShare()
 	for _, pi := range P {
-		pi.ckgShare = ckg.AllocateShares()
+		pi.ckgShare = ckg.AllocateShare()
 	}
 
 	crp := ckg.SampleCRP(crs)
@@ -391,7 +391,7 @@ func ckgphase(params bfv.Parameters, crs utils.PRNG, P []*party) *rlwe.PublicKey
 
 	elapsedCKGCloud = runTimed(func() {
 		for _, pi := range P {
-			ckg.AggregateShares(pi.ckgShare, ckgCombined, ckgCombined)
+			ckg.AggregateShare(pi.ckgShare, ckgCombined, ckgCombined)
 		}
 		ckg.GenPublicKey(ckgCombined, crp, pk)
 	})

--- a/examples/dbfv/psi/main.go
+++ b/examples/dbfv/psi/main.go
@@ -297,23 +297,23 @@ func pcksPhase(params bfv.Parameters, tpk *rlwe.PublicKey, encRes *bfv.Ciphertex
 	pcks := dbfv.NewPCKSProtocol(params, 3.19)
 
 	for _, pi := range P {
-		pi.pcksShare = pcks.AllocateShareBFV()
+		pi.pcksShare = pcks.AllocateShare()
 	}
 
 	l.Println("> PCKS Phase")
 	elapsedPCKSParty = runTimedParty(func() {
 		for _, pi := range P {
-			pcks.GenShare(pi.sk, tpk, encRes.Ciphertext, pi.pcksShare)
+			pcks.GenShare(pi.sk, tpk, encRes.Value[1], pi.pcksShare)
 		}
 	}, len(P))
 
-	pcksCombined := pcks.AllocateShareBFV()
+	pcksCombined := pcks.AllocateShare()
 	encOut = bfv.NewCiphertext(params, 1)
 	elapsedPCKSCloud = runTimed(func() {
 		for _, pi := range P {
 			pcks.AggregateShares(pi.pcksShare, pcksCombined, pcksCombined)
 		}
-		pcks.KeySwitch(pcksCombined, encRes.Ciphertext, encOut.Ciphertext)
+		pcks.KeySwitch(encRes, pcksCombined, encOut)
 
 	})
 	l.Printf("\tdone (cloud: %s, party: %s)\n", elapsedPCKSCloud, elapsedPCKSParty)

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -465,16 +465,16 @@ func (r *Ring) PolyToString(p1 *Poly) []string {
 
 // PolyToBigint reconstructs p1 and returns the result in an array of Int.
 // gap defines coefficients X^{i*gap} that will be reconstructed.
-// For example if gap = 1, then all coefficients are recontructed, while
-// if gap = 2 then only coefficients X^{2*i} are recontructed.
+// For example, if gap = 1, then all coefficients are reconstructed, while
+// if gap = 2 then only coefficients X^{2*i} are reconstructed.
 func (r *Ring) PolyToBigint(p1 *Poly, gap int, coeffsBigint []*big.Int) {
 	r.PolyToBigintLvl(p1.Level(), p1, gap, coeffsBigint)
 }
 
 // PolyToBigintLvl reconstructs p1 and returns the result in an array of Int.
 // gap defines coefficients X^{i*gap} that will be reconstructed.
-// For example if gap = 1, then all coefficients are recontructed, while
-// if gap = 2 then only coefficients X^{2*i} are recontructed.
+// For example, if gap = 1, then all coefficients are reconstructed, while
+// if gap = 2 then only coefficients X^{2*i} are reconstructed.
 func (r *Ring) PolyToBigintLvl(level int, p1 *Poly, gap int, coeffsBigint []*big.Int) {
 	var qi uint64
 
@@ -514,8 +514,8 @@ func (r *Ring) PolyToBigintLvl(level int, p1 *Poly, gap int, coeffsBigint []*big
 // PolyToBigintCenteredLvl reconstructs p1 and returns the result in an array of Int.
 // Coefficients are centered around Q/2
 // gap defines coefficients X^{i*gap} that will be reconstructed.
-// For example if gap = 1, then all coefficients are recontructed, while
-// if gap = 2 then only coefficients X^{2*i} are recontructed.
+// For example, if gap = 1, then all coefficients are reconstructed, while
+// if gap = 2 then only coefficients X^{2*i} are reconstructed.
 func (r *Ring) PolyToBigintCenteredLvl(level int, p1 *Poly, gap int, coeffsBigint []*big.Int) {
 	var qi uint64
 

--- a/ring/ring.go
+++ b/ring/ring.go
@@ -464,11 +464,17 @@ func (r *Ring) PolyToString(p1 *Poly) []string {
 }
 
 // PolyToBigint reconstructs p1 and returns the result in an array of Int.
+// gap defines coefficients X^{i*gap} that will be reconstructed.
+// For example if gap = 1, then all coefficients are recontructed, while
+// if gap = 2 then only coefficients X^{2*i} are recontructed.
 func (r *Ring) PolyToBigint(p1 *Poly, gap int, coeffsBigint []*big.Int) {
 	r.PolyToBigintLvl(p1.Level(), p1, gap, coeffsBigint)
 }
 
 // PolyToBigintLvl reconstructs p1 and returns the result in an array of Int.
+// gap defines coefficients X^{i*gap} that will be reconstructed.
+// For example if gap = 1, then all coefficients are recontructed, while
+// if gap = 2 then only coefficients X^{2*i} are recontructed.
 func (r *Ring) PolyToBigintLvl(level int, p1 *Poly, gap int, coeffsBigint []*big.Int) {
 	var qi uint64
 
@@ -507,6 +513,9 @@ func (r *Ring) PolyToBigintLvl(level int, p1 *Poly, gap int, coeffsBigint []*big
 
 // PolyToBigintCenteredLvl reconstructs p1 and returns the result in an array of Int.
 // Coefficients are centered around Q/2
+// gap defines coefficients X^{i*gap} that will be reconstructed.
+// For example if gap = 1, then all coefficients are recontructed, while
+// if gap = 2 then only coefficients X^{2*i} are recontructed.
 func (r *Ring) PolyToBigintCenteredLvl(level int, p1 *Poly, gap int, coeffsBigint []*big.Int) {
 	var qi uint64
 

--- a/ring/ring_basis_extension.go
+++ b/ring/ring_basis_extension.go
@@ -6,9 +6,9 @@ import (
 	"unsafe"
 )
 
-// FastBasisExtender stores the necessary parameters for RNS basis extension.
+// BasisExtender stores the necessary parameters for RNS basis extension.
 // The used algorithm is from https://eprint.iacr.org/2018/117.pdf.
-type FastBasisExtender struct {
+type BasisExtender struct {
 	ringQ             *Ring
 	ringP             *Ring
 	paramsQtoP        []modupParams
@@ -52,10 +52,10 @@ func genModDownParams(ringQ, ringP *Ring) (params [][]uint64) {
 	return
 }
 
-// NewFastBasisExtender creates a new FastBasisExtender, enabling RNS basis extension from Q to P and P to Q.
-func NewFastBasisExtender(ringQ, ringP *Ring) *FastBasisExtender {
+// NewBasisExtender creates a new BasisExtender, enabling RNS basis extension from Q to P and P to Q.
+func NewBasisExtender(ringQ, ringP *Ring) *BasisExtender {
 
-	newParams := new(FastBasisExtender)
+	newParams := new(BasisExtender)
 
 	newParams.ringQ = ringQ
 	newParams.ringP = ringP
@@ -153,11 +153,11 @@ func basisextenderparameters(Q, P []uint64) modupParams {
 
 // ShallowCopy creates a shallow copy of this basis extender in which the read-only data-structures are
 // shared with the receiver.
-func (be *FastBasisExtender) ShallowCopy() *FastBasisExtender {
+func (be *BasisExtender) ShallowCopy() *BasisExtender {
 	if be == nil {
 		return nil
 	}
-	return &FastBasisExtender{
+	return &BasisExtender{
 		ringQ:             be.ringQ,
 		ringP:             be.ringP,
 		paramsQtoP:        be.paramsQtoP,
@@ -173,14 +173,14 @@ func (be *FastBasisExtender) ShallowCopy() *FastBasisExtender {
 // ModUpQtoP extends the RNS basis of a polynomial from Q to QP.
 // Given a polynomial with coefficients in basis {Q0,Q1....Qlevel},
 // it extends its basis from {Q0,Q1....Qlevel} to {Q0,Q1....Qlevel,P0,P1...Pj}
-func (be *FastBasisExtender) ModUpQtoP(levelQ, levelP int, polQ, polP *Poly) {
+func (be *BasisExtender) ModUpQtoP(levelQ, levelP int, polQ, polP *Poly) {
 	modUpExact(polQ.Coeffs[:levelQ+1], polP.Coeffs[:levelP+1], be.ringQ, be.ringP, be.paramsQtoP[levelQ])
 }
 
 // ModUpPtoQ extends the RNS basis of a polynomial from P to PQ.
 // Given a polynomial with coefficients in basis {P0,P1....Plevel},
 // it extends its basis from {P0,P1....Plevel} to {Q0,Q1...Qj}
-func (be *FastBasisExtender) ModUpPtoQ(levelP, levelQ int, polP, polQ *Poly) {
+func (be *BasisExtender) ModUpPtoQ(levelP, levelQ int, polP, polQ *Poly) {
 	modUpExact(polP.Coeffs[:levelP+1], polQ.Coeffs[:levelQ+1], be.ringP, be.ringQ, be.paramsPtoQ[levelP])
 }
 
@@ -188,7 +188,7 @@ func (be *FastBasisExtender) ModUpPtoQ(levelP, levelQ int, polP, polQ *Poly) {
 // Given a polynomial with coefficients in basis {Q0,Q1....Qlevel} and {P0,P1...Pj},
 // it reduces its basis from {Q0,Q1....Qlevel} and {P0,P1...Pj} to {Q0,Q1....Qlevel}
 // and does a rounded integer division of the result by P.
-func (be *FastBasisExtender) ModDownQPtoQ(levelQ, levelP int, p1Q, p1P, p2Q *Poly) {
+func (be *BasisExtender) ModDownQPtoQ(levelQ, levelP int, p1Q, p1P, p2Q *Poly) {
 
 	ringQ := be.ringQ
 	modDownParams := be.modDownparamsPtoQ
@@ -211,7 +211,7 @@ func (be *FastBasisExtender) ModDownQPtoQ(levelQ, levelP int, p1Q, p1P, p2Q *Pol
 // it reduces its basis from {Q0,Q1....Qi} and {P0,P1...Pj} to {Q0,Q1....Qi}
 // and does a rounded integer division of the result by P.
 // Inputs must be in the NTT domain.
-func (be *FastBasisExtender) ModDownQPtoQNTT(levelQ, levelP int, p1Q, p1P, p2Q *Poly) {
+func (be *BasisExtender) ModDownQPtoQNTT(levelQ, levelP int, p1Q, p1P, p2Q *Poly) {
 
 	ringQ := be.ringQ
 	ringP := be.ringP
@@ -242,7 +242,7 @@ func (be *FastBasisExtender) ModDownQPtoQNTT(levelQ, levelP int, p1Q, p1P, p2Q *
 // Given a polynomial with coefficients in basis {Q0,Q1....QlevelQ} and {P0,P1...PlevelP},
 // it reduces its basis from {Q0,Q1....QlevelQ} and {P0,P1...PlevelP} to {P0,P1...PlevelP}
 // and does a floored integer division of the result by Q.
-func (be *FastBasisExtender) ModDownQPtoP(levelQ, levelP int, p1Q, p1P, p2P *Poly) {
+func (be *BasisExtender) ModDownQPtoP(levelQ, levelP int, p1Q, p1P, p2P *Poly) {
 
 	ringP := be.ringP
 	modDownParams := be.modDownparamsQtoP

--- a/ring/ring_benchmark_test.go
+++ b/ring/ring_benchmark_test.go
@@ -276,7 +276,7 @@ func benchExtendBasis(testContext *testParams, b *testing.B) {
 		rescaleParams[i] = RandUniform(testContext.prng, pi, (1<<uint64(bits.Len64(pi)-1) - 1))
 	}
 
-	basisExtender := NewFastBasisExtender(testContext.ringQ, testContext.ringP)
+	basisExtender := NewBasisExtender(testContext.ringQ, testContext.ringP)
 
 	p0 := testContext.uniformSamplerQ.ReadNew()
 	p1 := testContext.uniformSamplerP.ReadNew()

--- a/ring/ring_scaling.go
+++ b/ring/ring_scaling.go
@@ -239,7 +239,7 @@ func (ss *SimpleScaler) DivByQOverTRounded(p1, p2 *Poly) {
 func (ss *SimpleScaler) reconstructThenScale(p1, p2 *Poly) {
 
 	// reconstruction
-	ss.ringQ.PolyToBigint(p1, ss.p1BI)
+	ss.ringQ.PolyToBigint(p1, 1, ss.p1BI)
 
 	// scaling
 	for i, coeff := range ss.p1BI {

--- a/ring/ring_test.go
+++ b/ring/ring_test.go
@@ -605,7 +605,7 @@ func testExtendBasis(testContext *testParams, t *testing.T) {
 
 	t.Run(testString("ModUp/", testContext.ringQ), func(t *testing.T) {
 
-		basisextender := NewFastBasisExtender(testContext.ringQ, testContext.ringP)
+		basisextender := NewBasisExtender(testContext.ringQ, testContext.ringP)
 
 		levelQ := len(testContext.ringQ.Modulus) - 2
 		levelP := len(testContext.ringQ.Modulus) - 2
@@ -637,7 +637,7 @@ func testExtendBasis(testContext *testParams, t *testing.T) {
 
 	t.Run(testString("ModDown/", testContext.ringQ), func(t *testing.T) {
 
-		basisextender := NewFastBasisExtender(testContext.ringQ, testContext.ringP)
+		basisextender := NewBasisExtender(testContext.ringQ, testContext.ringP)
 
 		levelQ := len(testContext.ringQ.Modulus) - 2
 		levelP := len(testContext.ringP.Modulus) - 2

--- a/rlwe/decryptor.go
+++ b/rlwe/decryptor.go
@@ -21,9 +21,6 @@ type Decryptor interface {
 	// read-only data-structures are shared with the receiver and the temporary buffers
 	// are reallocated. The receiver and the returned Decryptor can be used concurrently.
 	WithKey(sk *SecretKey) Decryptor
-
-	// SetKey sets the key of the target decryptor.
-	SetKey(sk *SecretKey)
 }
 
 // decryptor is a structure used to decrypt ciphertext. It stores the secret-key.
@@ -53,11 +50,6 @@ func (d *decryptor) WithKey(sk *SecretKey) Decryptor {
 		pool:  d.ringQ.NewPoly(),
 		sk:    sk,
 	}
-}
-
-// SetKey sets the key of the target decryptor.
-func (d *decryptor) SetKey(sk *SecretKey) {
-	d.sk = sk
 }
 
 // NewDecryptor instantiates a new generic RLWE Decryptor.

--- a/rlwe/decryptor.go
+++ b/rlwe/decryptor.go
@@ -7,19 +7,8 @@ import (
 
 // Decryptor is an interface generic RLWE encryption.
 type Decryptor interface {
-	// Decrypt decrypts the ciphertext and write the result in ptOut.
-	// The level of the output plaintext is min(ciphertext.Level(), plaintext.Level())
-	// Output domain will match plaintext.Value.IsNTT value.
 	Decrypt(ciphertext *Ciphertext, plaintext *Plaintext)
-
-	// ShallowCopy creates a shallow copy of Decryptor in which all the read-only data-structures are
-	// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
-	// Decryptor can be used concurrently.
 	ShallowCopy() Decryptor
-
-	// WithKey creates a shallow copy of Decryptor with a new decryption key, in which all the
-	// read-only data-structures are shared with the receiver and the temporary buffers
-	// are reallocated. The receiver and the returned Decryptor can be used concurrently.
 	WithKey(sk *SecretKey) Decryptor
 }
 
@@ -28,28 +17,6 @@ type decryptor struct {
 	ringQ *ring.Ring
 	pool  *ring.Poly
 	sk    *SecretKey
-}
-
-// ShallowCopy creates a shallow copy of Decryptor in which all the read-only data-structures are
-// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
-// Decryptor can be used concurrently.
-func (d *decryptor) ShallowCopy() Decryptor {
-	return &decryptor{
-		ringQ: d.ringQ,
-		pool:  d.ringQ.NewPoly(),
-		sk:    d.sk,
-	}
-}
-
-// WithKey creates a shallow copy of Decryptor with a new decryption key, in which all the
-// read-only data-structures are shared with the receiver and the temporary buffers
-// are reallocated. The receiver and the returned Decryptor can be used concurrently.
-func (d *decryptor) WithKey(sk *SecretKey) Decryptor {
-	return &decryptor{
-		ringQ: d.ringQ,
-		pool:  d.ringQ.NewPoly(),
-		sk:    sk,
-	}
 }
 
 // NewDecryptor instantiates a new generic RLWE Decryptor.
@@ -105,5 +72,27 @@ func (d *decryptor) Decrypt(ciphertext *Ciphertext, plaintext *Plaintext) {
 
 	if !plaintext.Value.IsNTT {
 		ringQ.InvNTTLvl(level, plaintext.Value, plaintext.Value)
+	}
+}
+
+// ShallowCopy creates a shallow copy of Decryptor in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Decryptor can be used concurrently.
+func (d *decryptor) ShallowCopy() Decryptor {
+	return &decryptor{
+		ringQ: d.ringQ,
+		pool:  d.ringQ.NewPoly(),
+		sk:    d.sk,
+	}
+}
+
+// WithKey creates a shallow copy of Decryptor with a new decryption key, in which all the
+// read-only data-structures are shared with the receiver and the temporary buffers
+// are reallocated. The receiver and the returned Decryptor can be used concurrently.
+func (d *decryptor) WithKey(sk *SecretKey) Decryptor {
+	return &decryptor{
+		ringQ: d.ringQ,
+		pool:  d.ringQ.NewPoly(),
+		sk:    sk,
 	}
 }

--- a/rlwe/decryptor.go
+++ b/rlwe/decryptor.go
@@ -12,8 +12,18 @@ type Decryptor interface {
 	// Output domain will match plaintext.Value.IsNTT value.
 	Decrypt(ciphertext *Ciphertext, plaintext *Plaintext)
 
+	// ShallowCopy creates a shallow copy of Decryptor in which all the read-only data-structures are
+	// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+	// Decryptor can be used concurrently.
 	ShallowCopy() Decryptor
+
+	// WithKey creates a shallow copy of Decryptor with a new decryption key, in which all the
+	// read-only data-structures are shared with the receiver and the temporary buffers
+	// are reallocated. The receiver and the returned Decryptor can be used concurrently.
 	WithKey(sk *SecretKey) Decryptor
+
+	// SetKey sets the key of the target decryptor.
+	SetKey(sk *SecretKey)
 }
 
 // decryptor is a structure used to decrypt ciphertext. It stores the secret-key.
@@ -43,6 +53,11 @@ func (d *decryptor) WithKey(sk *SecretKey) Decryptor {
 		pool:  d.ringQ.NewPoly(),
 		sk:    sk,
 	}
+}
+
+// SetKey sets the key of the target decryptor.
+func (d *decryptor) SetKey(sk *SecretKey) {
+	d.sk = sk
 }
 
 // NewDecryptor instantiates a new generic RLWE Decryptor.

--- a/rlwe/decryptor.go
+++ b/rlwe/decryptor.go
@@ -11,14 +11,38 @@ type Decryptor interface {
 	// The level of the output plaintext is min(ciphertext.Level(), plaintext.Level())
 	// Output domain will match plaintext.Value.IsNTT value.
 	Decrypt(ciphertext *Ciphertext, plaintext *Plaintext)
+
+	ShallowCopy() Decryptor
+	WithKey(sk *SecretKey) Decryptor
 }
 
 // decryptor is a structure used to decrypt ciphertext. It stores the secret-key.
 type decryptor struct {
-	params Parameters
-	ringQ  *ring.Ring
-	pool   *ring.Poly
-	sk     *SecretKey
+	ringQ *ring.Ring
+	pool  *ring.Poly
+	sk    *SecretKey
+}
+
+// ShallowCopy creates a shallow copy of Decryptor in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Decryptor can be used concurrently.
+func (d *decryptor) ShallowCopy() Decryptor {
+	return &decryptor{
+		ringQ: d.ringQ,
+		pool:  d.ringQ.NewPoly(),
+		sk:    d.sk,
+	}
+}
+
+// WithKey creates a shallow copy of Decryptor with a new decryption key, in which all the
+// read-only data-structures are shared with the receiver and the temporary buffers
+// are reallocated. The receiver and the returned Decryptor can be used concurrently.
+func (d *decryptor) WithKey(sk *SecretKey) Decryptor {
+	return &decryptor{
+		ringQ: d.ringQ,
+		pool:  d.ringQ.NewPoly(),
+		sk:    sk,
+	}
 }
 
 // NewDecryptor instantiates a new generic RLWE Decryptor.
@@ -29,19 +53,18 @@ func NewDecryptor(params Parameters, sk *SecretKey) Decryptor {
 	}
 
 	return &decryptor{
-		params: params,
-		ringQ:  params.RingQ(),
-		pool:   params.RingQ().NewPoly(),
-		sk:     sk,
+		ringQ: params.RingQ(),
+		pool:  params.RingQ().NewPoly(),
+		sk:    sk,
 	}
 }
 
 // Decrypt decrypts the ciphertext and write the result in ptOut.
 // The level of the output plaintext is min(ciphertext.Level(), plaintext.Level())
 // Output domain will match plaintext.Value.IsNTT value.
-func (decryptor *decryptor) Decrypt(ciphertext *Ciphertext, plaintext *Plaintext) {
+func (d *decryptor) Decrypt(ciphertext *Ciphertext, plaintext *Plaintext) {
 
-	ringQ := decryptor.ringQ
+	ringQ := d.ringQ
 
 	level := utils.MinInt(ciphertext.Level(), plaintext.Level())
 
@@ -55,11 +78,11 @@ func (decryptor *decryptor) Decrypt(ciphertext *Ciphertext, plaintext *Plaintext
 
 	for i := ciphertext.Degree(); i > 0; i-- {
 
-		ringQ.MulCoeffsMontgomeryLvl(level, plaintext.Value, decryptor.sk.Value.Q, plaintext.Value)
+		ringQ.MulCoeffsMontgomeryLvl(level, plaintext.Value, d.sk.Value.Q, plaintext.Value)
 
 		if !ciphertext.Value[0].IsNTT {
-			ringQ.NTTLazyLvl(level, ciphertext.Value[i-1], decryptor.pool)
-			ringQ.AddLvl(level, plaintext.Value, decryptor.pool, plaintext.Value)
+			ringQ.NTTLazyLvl(level, ciphertext.Value[i-1], d.pool)
+			ringQ.AddLvl(level, plaintext.Value, d.pool, plaintext.Value)
 		} else {
 			ringQ.AddLvl(level, plaintext.Value, ciphertext.Value[i-1], plaintext.Value)
 		}

--- a/rlwe/elements.go
+++ b/rlwe/elements.go
@@ -40,13 +40,9 @@ func NewAdditiveShareAtLevel(params Parameters, level int) *AdditiveShare {
 	return &AdditiveShare{Value: *ring.NewPoly(params.N(), level+1)}
 }
 
-// NewAdditiveShareBigint instantiate a new additive share struct composed of big.Int elements
-func NewAdditiveShareBigint(params Parameters, logSlots int) *AdditiveShareBigint {
-	dslots := 1 << logSlots
-	if params.RingType() == ring.Standard {
-		dslots *= 2
-	}
-	v := make([]*big.Int, dslots)
+// NewAdditiveShareBigint instantiate a new additive share struct composed of "n" big.Int elements
+func NewAdditiveShareBigint(params Parameters, n int) *AdditiveShareBigint {
+	v := make([]*big.Int, n)
 	for i := range v {
 		v[i] = new(big.Int)
 	}

--- a/rlwe/elements.go
+++ b/rlwe/elements.go
@@ -41,8 +41,12 @@ func NewAdditiveShareAtLevel(params Parameters, level int) *AdditiveShare {
 }
 
 // NewAdditiveShareBigint instantiate a new additive share struct composed of big.Int elements
-func NewAdditiveShareBigint(params Parameters) *AdditiveShareBigint {
-	v := make([]*big.Int, params.N())
+func NewAdditiveShareBigint(params Parameters, logSlots int) *AdditiveShareBigint {
+	dslots := 1 << logSlots
+	if params.RingType() == ring.Standard {
+		dslots *= 2
+	}
+	v := make([]*big.Int, dslots)
 	for i := range v {
 		v[i] = new(big.Int)
 	}

--- a/rlwe/encryptor.go
+++ b/rlwe/encryptor.go
@@ -7,21 +7,9 @@ import (
 
 // Encryptor a generic RLWE encryption interface.
 type Encryptor interface {
-	// Encrypt encrypts the input plaintext and write the result on ct.
-	// The encryption algorithm depends on the implementor.
 	Encrypt(pt *Plaintext, ct *Ciphertext)
-
-	// EncryptFromCRP encrypts the input plaintext and writes the result on ct.
-	// The encryption algorithm depends on the implementor.
 	EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext)
-
-	// ShallowCopy creates a shallow copy of this encryptor in which all the read-only data-structures are
-	// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
-	// Encryptors can be used concurrently.
 	ShallowCopy() Encryptor
-
-	// WithKey creates a shallow copy of the receiver Encryptor with the provided key.
-	// This is equivalent to calling Encryptor.ShallowCopy().SetKey(*)
 	WithKey(key interface{}) Encryptor
 }
 
@@ -128,14 +116,59 @@ func newEncryptorBuffers(params Parameters) *encryptorBuffers {
 	}
 }
 
+// Encrypt encrypts the input plaintext using the stored public-key and write the result on ct.
+// The encryption procedure first samples an new encryption of zero under the public-key and
+// then adds the plaintext.
+// The encryption procedures depends on the parameters. If the auxiliary modulus P is defined,
+// then the encryption of zero is sampled in QP before being rescaled by P, else it is directly
+// samples in Q.
+func (enc *pkEncryptor) Encrypt(pt *Plaintext, ct *Ciphertext) {
+	enc.encrypt(pt, enc.pk, ct)
+}
+
+// EncryptFromCRP is not defined when using a public-key. This method will panic.
+func (enc *pkEncryptor) EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext) {
+	enc.encryptFromCRP(pt, enc.pk, ct)
+}
+
+// Encrypt encrypts the input plaintext and write the result on ct.
+func (enc *skEncryptor) Encrypt(pt *Plaintext, ct *Ciphertext) {
+	enc.encrypt(pt, enc.sk, ct)
+}
+
+// EncryptFromCRP encrypts the input plaintext and writes the result on ct.
+// The encryption algorithm depends on the implementor.
+func (enc *skEncryptor) EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext) {
+	enc.encryptFromCRP(pt, enc.sk, ct)
+}
+
+// Encrypt is not defined when the key is nil. This method will panic.
+func (enc *encryptor) Encrypt(pt *Plaintext, ct *Ciphertext) {
+	panic("cannot encrypt, key is nil")
+}
+
+// EncryptFromCRP is not defined when the key is nil. This method will panic.
+func (enc *encryptor) EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext) {
+	panic("cannot encrypt, key is nil")
+}
+
+// ShallowCopy creates a shallow copy of this pkEncryptor in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Encryptors can be used concurrently.
 func (enc *pkEncryptor) ShallowCopy() Encryptor {
 	return &pkEncryptor{*enc.encryptor.ShallowCopy().(*encryptor), enc.pk}
 }
 
+// ShallowCopy creates a shallow copy of this skEncryptor in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Encryptors can be used concurrently.
 func (enc *skEncryptor) ShallowCopy() Encryptor {
 	return &skEncryptor{*enc.encryptor.ShallowCopy().(*encryptor), enc.sk}
 }
 
+// ShallowCopy creates a shallow copy of this encryptor in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Encryptors can be used concurrently.
 func (enc *encryptor) ShallowCopy() Encryptor {
 
 	var bc *ring.BasisExtender
@@ -151,68 +184,27 @@ func (enc *encryptor) ShallowCopy() Encryptor {
 	}
 }
 
+// WithKey creates a shallow copy of this pkEncryptor with a new key in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Encryptors can be used concurrently.
 func (enc *pkEncryptor) WithKey(key interface{}) Encryptor {
 	return enc.ShallowCopy().(*pkEncryptor).setKey(key)
 }
 
+// WithKey creates a shallow copy of this skEncryptor with a new key in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Encryptors can be used concurrently.
 func (enc *skEncryptor) WithKey(key interface{}) Encryptor {
 	return enc.ShallowCopy().(*skEncryptor).setKey(key)
 }
 
+// WithKey creates a shallow copy of this encryptor with a new key in which all the read-only data-structures are
+// shared with the receiver and the temporary buffers are reallocated. The receiver and the returned
+// Encryptors can be used concurrently.
 func (enc *encryptor) WithKey(key interface{}) Encryptor {
 	return enc.ShallowCopy().(*encryptor).setKey(key)
 }
 
-func (enc *pkEncryptor) setKey(key interface{}) Encryptor {
-	return enc.encryptor.setKey(key)
-}
-
-func (enc *skEncryptor) setKey(key interface{}) Encryptor {
-	return enc.encryptor.setKey(key)
-}
-
-func (enc *encryptor) setKey(key interface{}) Encryptor {
-	switch key := key.(type) {
-	case *PublicKey:
-		if key.Value[0].Q.Degree() != enc.params.N() || key.Value[1].Q.Degree() != enc.params.N() {
-			panic("cannot newEncryptor: pk ring degree does not match params ring degree")
-		}
-		return &pkEncryptor{*enc, key}
-	case *SecretKey:
-		if key.Value.Q.Degree() != enc.params.N() {
-			panic("cannot newEncryptor: sk ring degree does not match params ring degree")
-		}
-		return &skEncryptor{*enc, key}
-	default:
-		panic("key must be either *rlwe.PublicKey or *rlwe.SecretKey")
-	}
-}
-
-func (enc *pkEncryptor) Encrypt(pt *Plaintext, ct *Ciphertext) {
-	enc.encrypt(pt, enc.pk, ct)
-}
-
-func (enc *pkEncryptor) EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext) {
-	enc.encrypt(pt, enc.pk, ct)
-}
-
-func (enc *skEncryptor) Encrypt(pt *Plaintext, ct *Ciphertext) {
-	enc.encrypt(pt, enc.sk, ct)
-}
-
-func (enc *skEncryptor) EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext) {
-	enc.encrypt(pt, enc.sk, ct)
-}
-
-func (enc *encryptor) Encrypt(pt *Plaintext, ct *Ciphertext) {
-	panic("cannot encrypt, key is nil")
-}
-
-func (enc *encryptor) EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext) {
-	panic("cannot encrypt, key is nil")
-}
-
-// Encrypt encrypts the input Plaintext and write the result in ctOut.
 func (enc *encryptor) encrypt(plaintext *Plaintext, key interface{}, ciphertext *Ciphertext) {
 	switch key := key.(type) {
 	case *PublicKey:
@@ -239,7 +231,6 @@ func (enc *encryptor) encrypt(plaintext *Plaintext, key interface{}, ciphertext 
 	}
 }
 
-// EncryptFromCRP encrypts the input Plaintext given the uniformly random element c1 and write the result in ctOut.
 func (enc *encryptor) encryptFromCRP(plaintext *Plaintext, key interface{}, crp *ring.Poly, ciphertext *Ciphertext) {
 	switch key := key.(type) {
 	case *PublicKey:
@@ -459,4 +450,29 @@ func (enc *encryptor) encryptSk(plaintext *Plaintext, sk *SecretKey, ciphertext 
 
 	ciphertext.Value[0].Coeffs = ciphertext.Value[0].Coeffs[:levelQ+1]
 	ciphertext.Value[1].Coeffs = ciphertext.Value[1].Coeffs[:levelQ+1]
+}
+
+func (enc *pkEncryptor) setKey(key interface{}) Encryptor {
+	return enc.encryptor.setKey(key)
+}
+
+func (enc *skEncryptor) setKey(key interface{}) Encryptor {
+	return enc.encryptor.setKey(key)
+}
+
+func (enc *encryptor) setKey(key interface{}) Encryptor {
+	switch key := key.(type) {
+	case *PublicKey:
+		if key.Value[0].Q.Degree() != enc.params.N() || key.Value[1].Q.Degree() != enc.params.N() {
+			panic("cannot newEncryptor: pk ring degree does not match params ring degree")
+		}
+		return &pkEncryptor{*enc, key}
+	case *SecretKey:
+		if key.Value.Q.Degree() != enc.params.N() {
+			panic("cannot newEncryptor: sk ring degree does not match params ring degree")
+		}
+		return &skEncryptor{*enc, key}
+	default:
+		panic("key must be either *rlwe.PublicKey or *rlwe.SecretKey")
+	}
 }

--- a/rlwe/encryptor.go
+++ b/rlwe/encryptor.go
@@ -128,7 +128,7 @@ func (enc *pkEncryptor) Encrypt(pt *Plaintext, ct *Ciphertext) {
 
 // EncryptFromCRP is not defined when using a public-key. This method will panic.
 func (enc *pkEncryptor) EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext) {
-	enc.encryptFromCRP(pt, enc.pk, ct)
+	enc.encryptFromCRP(pt, enc.pk, crp, ct)
 }
 
 // Encrypt encrypts the input plaintext and write the result on ct.
@@ -139,7 +139,7 @@ func (enc *skEncryptor) Encrypt(pt *Plaintext, ct *Ciphertext) {
 // EncryptFromCRP encrypts the input plaintext and writes the result on ct.
 // The encryption algorithm depends on the implementor.
 func (enc *skEncryptor) EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext) {
-	enc.encryptFromCRP(pt, enc.sk, ct)
+	enc.encryptFromCRP(pt, enc.sk, crp, ct)
 }
 
 // Encrypt is not defined when the key is nil. This method will panic.

--- a/rlwe/encryptor.go
+++ b/rlwe/encryptor.go
@@ -7,13 +7,13 @@ import (
 
 // Encryptor a generic RLWE encryption interface.
 type Encryptor interface {
-	// Encrypt encrypts the input plaintext and write the result on ctOut.
+	// Encrypt encrypts the input plaintext and write the result on ct.
 	// The encryption algorithm depends on the implementor.
-	Encrypt(pt *Plaintext, ctOut *Ciphertext)
+	Encrypt(pt *Plaintext, ct *Ciphertext)
 
-	// EncryptFromCRP encrypts the input plaintext and writes the result in ctOut.
+	// EncryptFromCRP encrypts the input plaintext and writes the result on ct.
 	// The encryption algorithm depends on the implementor.
-	EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ctOut *Ciphertext)
+	EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext)
 }
 
 // encryptorBase is a struct used to encrypt Plaintexts. It stores the public-key and/or secret-key.
@@ -26,18 +26,13 @@ type encryptorBase struct {
 	poolQ [1]*ring.Poly
 	poolP [3]*ring.Poly
 
+	baseconverter   *ring.FastBasisExtender
 	gaussianSampler *ring.GaussianSampler
 	ternarySampler  *ring.TernarySampler
 	uniformSampler  *ring.UniformSampler
 }
 
 type pkEncryptor struct {
-	encryptorBase
-	pk            *PublicKey
-	baseconverter *ring.FastBasisExtender
-}
-
-type pkFastEncryptor struct {
 	encryptorBase
 	pk *PublicKey
 }
@@ -47,20 +42,31 @@ type skEncryptor struct {
 	sk *SecretKey
 }
 
-// NewEncryptor instatiates a new generic RLWE Encryptor. The key argument can
-// be either a *rlwe.PublicKey or a *rlwe.SecretKey.
+func (enc *pkEncryptor) Encrypt(pt *Plaintext, ct *Ciphertext) {
+	enc.encrypt(pt, enc.pk, ct)
+}
+
+func (enc *pkEncryptor) EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext) {
+	enc.encrypt(pt, enc.pk, ct)
+}
+
+func (enc *skEncryptor) Encrypt(pt *Plaintext, ct *Ciphertext) {
+	enc.encrypt(pt, enc.sk, ct)
+}
+
+func (enc *skEncryptor) EncryptFromCRP(pt *Plaintext, crp *ring.Poly, ct *Ciphertext) {
+	enc.encrypt(pt, enc.sk, ct)
+}
+
+// NewEncryptor creates a new Encryptor
+// Accepts either a secret-key or a public-key
 func NewEncryptor(params Parameters, key interface{}) Encryptor {
 	switch key := key.(type) {
 	case *PublicKey:
 		if key.Value[0].Q.Degree() != params.N() || key.Value[1].Q.Degree() != params.N() {
 			panic("cannot newEncryptor: pk ring degree does not match params ring degree")
 		}
-		encryptorBase := newEncryptorBase(params)
-		if params.PCount() > 0 {
-			baseconverter := ring.NewFastBasisExtender(params.ringQ, params.ringP)
-			return &pkEncryptor{encryptorBase, key, baseconverter}
-		}
-		return &pkFastEncryptor{encryptorBase, key}
+		return &pkEncryptor{newEncryptorBase(params), key}
 	case *SecretKey:
 		if key.Value.Q.Degree() != params.N() {
 			panic("cannot newEncryptor: sk ring degree does not match params ring degree")
@@ -71,46 +77,122 @@ func NewEncryptor(params Parameters, key interface{}) Encryptor {
 	}
 }
 
-// NewFastEncryptor instantiates a new  generic RLWE Encryptor.
-// This encryptor's Encrypt method first encrypts zero in Q and then adds the plaintext.
-// This method is faster than the normal encryptor but result in a noisier ciphertext.
-func NewFastEncryptor(params Parameters, key *PublicKey) Encryptor {
-	return &pkFastEncryptor{newEncryptorBase(params), key}
+func newEncryptorBase(params Parameters) encryptorBase {
+
+	ringQ := params.RingQ()
+	ringP := params.RingP()
+
+	prng, err := utils.NewPRNG()
+	if err != nil {
+		panic(err)
+	}
+
+	var poolP [3]*ring.Poly
+	var bc *ring.FastBasisExtender
+	if params.PCount() != 0 {
+		poolP = [3]*ring.Poly{ringP.NewPoly(), ringP.NewPoly(), ringP.NewPoly()}
+		bc = ring.NewFastBasisExtender(ringQ, ringP)
+	}
+
+	return encryptorBase{
+		params:          params,
+		ringQ:           ringQ,
+		ringP:           ringP,
+		poolQ:           [1]*ring.Poly{ringQ.NewPoly()},
+		poolP:           poolP,
+		baseconverter:   bc,
+		gaussianSampler: ring.NewGaussianSampler(prng, ringQ, params.Sigma(), int(6*params.Sigma())),
+		ternarySampler:  ring.NewTernarySampler(prng, ringQ, 0.5, false),
+		uniformSampler:  ring.NewUniformSampler(prng, ringQ),
+	}
 }
 
 // Encrypt encrypts the input Plaintext and write the result in ctOut.
-func (encryptor *pkEncryptor) Encrypt(plaintext *Plaintext, ctOut *Ciphertext) {
-	ringQ := encryptor.ringQ
-	ringQP := encryptor.params.RingQP()
+func (enc *encryptorBase) encrypt(plaintext *Plaintext, key interface{}, ciphertext *Ciphertext) {
+	switch key := key.(type) {
+	case *PublicKey:
 
-	levelQ := utils.MinInt(plaintext.Level(), ctOut.Level())
+		if key.Value[0].Q.Degree() != enc.params.N() || key.Value[1].Q.Degree() != enc.params.N() {
+			panic("cannot newEncryptor: pk ring degree does not match params ring degree")
+		}
+
+		enc.uniformSampler.ReadLvl(utils.MinInt(plaintext.Level(), ciphertext.Level()), ciphertext.Value[1])
+
+		if enc.baseconverter != nil {
+			enc.encryptPk(plaintext, key, ciphertext)
+		} else {
+			enc.encryptPkNoP(plaintext, key, ciphertext)
+		}
+
+	case *SecretKey:
+
+		if key.Value.Q.Degree() != enc.params.N() {
+			panic("cannot newEncryptor: sk ring degree does not match params ring degree")
+		}
+
+		enc.uniformSampler.ReadLvl(utils.MinInt(plaintext.Level(), ciphertext.Level()), ciphertext.Value[1])
+
+		enc.encryptSk(plaintext, key, ciphertext)
+
+	default:
+		panic("key must be either rlwe.PublicKey or rlwe.SecretKey")
+	}
+}
+
+// EncryptFromCRP encrypts the input Plaintext given the uniformly random element c1 and write the result in ctOut.
+func (enc *encryptorBase) encryptFromCRP(plaintext *Plaintext, key interface{}, crp *ring.Poly, ciphertext *Ciphertext) {
+	switch key := key.(type) {
+	case *PublicKey:
+
+		panic("Cannot encrypt with CRP using a public-key")
+
+	case *SecretKey:
+
+		if key.Value.Q.Degree() != enc.params.N() {
+			panic("cannot newEncryptor: sk ring degree does not match params ring degree")
+		}
+
+		ring.CopyValues(crp, ciphertext.Value[1])
+
+		enc.encryptSk(plaintext, key, ciphertext)
+
+	default:
+		panic("key must be either rlwe.PublicKey or rlwe.SecretKey")
+	}
+}
+
+func (enc *encryptorBase) encryptPk(plaintext *Plaintext, pk *PublicKey, ciphertext *Ciphertext) {
+	ringQ := enc.ringQ
+	ringQP := enc.params.RingQP()
+
+	levelQ := utils.MinInt(plaintext.Level(), ciphertext.Level())
 	levelP := 0
 
-	poolQ0 := encryptor.poolQ[0]
-	poolP0 := encryptor.poolP[0]
-	poolP1 := encryptor.poolP[1]
-	poolP2 := encryptor.poolP[2]
+	poolQ0 := enc.poolQ[0]
+	poolP0 := enc.poolP[0]
+	poolP1 := enc.poolP[1]
+	poolP2 := enc.poolP[2]
 
 	// We sample a R-WLE instance (encryption of zero) over the extended ring (ciphertext ring + special prime)
 
-	ciphertextNTT := ctOut.Value[0].IsNTT
+	ciphertextNTT := ciphertext.Value[0].IsNTT
 
 	u := PolyQP{Q: poolQ0, P: poolP2}
 
-	encryptor.ternarySampler.ReadLvl(levelQ, u.Q)
+	enc.ternarySampler.ReadLvl(levelQ, u.Q)
 	ringQP.ExtendBasisSmallNormAndCenter(u.Q, levelP, nil, u.P)
 
 	// (#Q + #P) NTT
 	ringQP.NTTLvl(levelQ, levelP, u, u)
 	ringQP.MFormLvl(levelQ, levelP, u, u)
 
-	ct0QP := PolyQP{Q: ctOut.Value[0], P: poolP0}
-	ct1QP := PolyQP{Q: ctOut.Value[1], P: poolP1}
+	ct0QP := PolyQP{Q: ciphertext.Value[0], P: poolP0}
+	ct1QP := PolyQP{Q: ciphertext.Value[1], P: poolP1}
 
 	// ct0 = u*pk0
 	// ct1 = u*pk1
-	ringQP.MulCoeffsMontgomeryLvl(levelQ, levelP, u, encryptor.pk.Value[0], ct0QP)
-	ringQP.MulCoeffsMontgomeryLvl(levelQ, levelP, u, encryptor.pk.Value[1], ct1QP)
+	ringQP.MulCoeffsMontgomeryLvl(levelQ, levelP, u, pk.Value[0], ct0QP)
+	ringQP.MulCoeffsMontgomeryLvl(levelQ, levelP, u, pk.Value[1], ct1QP)
 
 	// 2*(#Q + #P) NTT
 	ringQP.InvNTTLvl(levelQ, levelP, ct0QP, ct0QP)
@@ -118,144 +200,129 @@ func (encryptor *pkEncryptor) Encrypt(plaintext *Plaintext, ctOut *Ciphertext) {
 
 	e := PolyQP{Q: poolQ0, P: poolP2}
 
-	encryptor.gaussianSampler.ReadLvl(levelQ, e.Q)
+	enc.gaussianSampler.ReadLvl(levelQ, e.Q)
 	ringQP.ExtendBasisSmallNormAndCenter(e.Q, levelP, nil, e.P)
 	ringQP.AddLvl(levelQ, levelP, ct0QP, e, ct0QP)
 
-	encryptor.gaussianSampler.ReadLvl(levelQ, e.Q)
+	enc.gaussianSampler.ReadLvl(levelQ, e.Q)
 	ringQP.ExtendBasisSmallNormAndCenter(e.Q, levelP, nil, e.P)
 	ringQP.AddLvl(levelQ, levelP, ct1QP, e, ct1QP)
 
 	// ct0 = (u*pk0 + e0)/P
-	encryptor.baseconverter.ModDownQPtoQ(levelQ, levelP, ct0QP.Q, ct0QP.P, ct0QP.Q)
+	enc.baseconverter.ModDownQPtoQ(levelQ, levelP, ct0QP.Q, ct0QP.P, ct0QP.Q)
 
 	// ct1 = (u*pk1 + e1)/P
-	encryptor.baseconverter.ModDownQPtoQ(levelQ, levelP, ct1QP.Q, ct1QP.P, ct1QP.Q)
+	enc.baseconverter.ModDownQPtoQ(levelQ, levelP, ct1QP.Q, ct1QP.P, ct1QP.Q)
 
 	if ciphertextNTT {
 
 		if !plaintext.Value.IsNTT {
-			ringQ.AddLvl(levelQ, ctOut.Value[0], plaintext.Value, ctOut.Value[0])
+			ringQ.AddLvl(levelQ, ciphertext.Value[0], plaintext.Value, ciphertext.Value[0])
 		}
 
 		// 2*#Q NTT
-		ringQ.NTTLvl(levelQ, ctOut.Value[0], ctOut.Value[0])
-		ringQ.NTTLvl(levelQ, ctOut.Value[1], ctOut.Value[1])
+		ringQ.NTTLvl(levelQ, ciphertext.Value[0], ciphertext.Value[0])
+		ringQ.NTTLvl(levelQ, ciphertext.Value[1], ciphertext.Value[1])
 
 		if plaintext.Value.IsNTT {
 			// ct0 = (u*pk0 + e0)/P + m
-			ringQ.AddLvl(levelQ, ctOut.Value[0], plaintext.Value, ctOut.Value[0])
+			ringQ.AddLvl(levelQ, ciphertext.Value[0], plaintext.Value, ciphertext.Value[0])
 		}
 
 	} else {
 
 		if !plaintext.Value.IsNTT {
-			ringQ.AddLvl(levelQ, ctOut.Value[0], plaintext.Value, ctOut.Value[0])
+			ringQ.AddLvl(levelQ, ciphertext.Value[0], plaintext.Value, ciphertext.Value[0])
 		} else {
 			ringQ.InvNTTLvl(levelQ, plaintext.Value, poolQ0)
-			ringQ.AddLvl(levelQ, ctOut.Value[0], poolQ0, ctOut.Value[0])
+			ringQ.AddLvl(levelQ, ciphertext.Value[0], poolQ0, ciphertext.Value[0])
 		}
 	}
 
-	ctOut.Value[1].IsNTT = ctOut.Value[0].IsNTT
-	ctOut.Value[0].Coeffs = ctOut.Value[0].Coeffs[:levelQ+1]
-	ctOut.Value[1].Coeffs = ctOut.Value[1].Coeffs[:levelQ+1]
+	ciphertext.Value[1].IsNTT = ciphertext.Value[0].IsNTT
+	ciphertext.Value[0].Coeffs = ciphertext.Value[0].Coeffs[:levelQ+1]
+	ciphertext.Value[1].Coeffs = ciphertext.Value[1].Coeffs[:levelQ+1]
 }
 
-// Encrypt encrypts the input Plaintext and write the result in ctOut.
-// It first encrypts zero in Q and then adds the plaintext.
-// This method is faster than the normal encryptor but result in a noisier ciphertext.
-func (encryptor *pkFastEncryptor) Encrypt(plaintext *Plaintext, ctOut *Ciphertext) {
-	levelQ := utils.MinInt(plaintext.Level(), ctOut.Level())
+func (enc *encryptorBase) encryptPkNoP(plaintext *Plaintext, pk *PublicKey, ciphertext *Ciphertext) {
+	levelQ := utils.MinInt(plaintext.Level(), ciphertext.Level())
 
-	poolQ0 := encryptor.poolQ[0]
+	poolQ0 := enc.poolQ[0]
 
-	ringQ := encryptor.ringQ
+	ringQ := enc.ringQ
 
-	ciphertextNTT := ctOut.Value[0].IsNTT
+	ciphertextNTT := ciphertext.Value[0].IsNTT
 
-	encryptor.ternarySampler.ReadLvl(levelQ, poolQ0)
+	enc.ternarySampler.ReadLvl(levelQ, poolQ0)
 	ringQ.NTTLvl(levelQ, poolQ0, poolQ0)
 	ringQ.MFormLvl(levelQ, poolQ0, poolQ0)
 
 	// ct0 = u*pk0
-	ringQ.MulCoeffsMontgomeryLvl(levelQ, poolQ0, encryptor.pk.Value[0].Q, ctOut.Value[0])
+	ringQ.MulCoeffsMontgomeryLvl(levelQ, poolQ0, pk.Value[0].Q, ciphertext.Value[0])
 	// ct1 = u*pk1
-	ringQ.MulCoeffsMontgomeryLvl(levelQ, poolQ0, encryptor.pk.Value[1].Q, ctOut.Value[1])
+	ringQ.MulCoeffsMontgomeryLvl(levelQ, poolQ0, pk.Value[1].Q, ciphertext.Value[1])
 
 	if ciphertextNTT {
 
 		// ct1 = u*pk1 + e1
-		encryptor.gaussianSampler.ReadLvl(levelQ, poolQ0)
+		enc.gaussianSampler.ReadLvl(levelQ, poolQ0)
 		ringQ.NTTLvl(levelQ, poolQ0, poolQ0)
-		ringQ.AddLvl(levelQ, ctOut.Value[1], poolQ0, ctOut.Value[1])
+		ringQ.AddLvl(levelQ, ciphertext.Value[1], poolQ0, ciphertext.Value[1])
 
 		// ct0 = u*pk0 + e0
-		encryptor.gaussianSampler.ReadLvl(levelQ, poolQ0)
+		enc.gaussianSampler.ReadLvl(levelQ, poolQ0)
 
 		if !plaintext.Value.IsNTT {
 			ringQ.AddLvl(levelQ, poolQ0, plaintext.Value, poolQ0)
 			ringQ.NTTLvl(levelQ, poolQ0, poolQ0)
-			ringQ.AddLvl(levelQ, ctOut.Value[0], poolQ0, ctOut.Value[0])
+			ringQ.AddLvl(levelQ, ciphertext.Value[0], poolQ0, ciphertext.Value[0])
 		} else {
 			ringQ.NTTLvl(levelQ, poolQ0, poolQ0)
-			ringQ.AddLvl(levelQ, ctOut.Value[0], poolQ0, ctOut.Value[0])
-			ringQ.AddLvl(levelQ, ctOut.Value[0], plaintext.Value, ctOut.Value[0])
+			ringQ.AddLvl(levelQ, ciphertext.Value[0], poolQ0, ciphertext.Value[0])
+			ringQ.AddLvl(levelQ, ciphertext.Value[0], plaintext.Value, ciphertext.Value[0])
 		}
 
 	} else {
 
-		ringQ.InvNTTLvl(levelQ, ctOut.Value[0], ctOut.Value[0])
-		ringQ.InvNTTLvl(levelQ, ctOut.Value[1], ctOut.Value[1])
+		ringQ.InvNTTLvl(levelQ, ciphertext.Value[0], ciphertext.Value[0])
+		ringQ.InvNTTLvl(levelQ, ciphertext.Value[1], ciphertext.Value[1])
 
 		// ct[0] = pk[0]*u + e0
-		encryptor.gaussianSampler.ReadAndAddLvl(ctOut.Level(), ctOut.Value[0])
+		enc.gaussianSampler.ReadAndAddLvl(ciphertext.Level(), ciphertext.Value[0])
 
 		// ct[1] = pk[1]*u + e1
-		encryptor.gaussianSampler.ReadAndAddLvl(ctOut.Level(), ctOut.Value[1])
+		enc.gaussianSampler.ReadAndAddLvl(ciphertext.Level(), ciphertext.Value[1])
 
 		if !plaintext.Value.IsNTT {
-			ringQ.AddLvl(levelQ, ctOut.Value[0], plaintext.Value, ctOut.Value[0])
+			ringQ.AddLvl(levelQ, ciphertext.Value[0], plaintext.Value, ciphertext.Value[0])
 		} else {
 			ringQ.InvNTTLvl(levelQ, plaintext.Value, poolQ0)
-			ringQ.AddLvl(levelQ, ctOut.Value[0], poolQ0, ctOut.Value[0])
+			ringQ.AddLvl(levelQ, ciphertext.Value[0], poolQ0, ciphertext.Value[0])
 		}
 	}
 
-	ctOut.Value[1].IsNTT = ctOut.Value[0].IsNTT
+	ciphertext.Value[1].IsNTT = ciphertext.Value[0].IsNTT
 
-	ctOut.Value[0].Coeffs = ctOut.Value[0].Coeffs[:levelQ+1]
-	ctOut.Value[1].Coeffs = ctOut.Value[1].Coeffs[:levelQ+1]
+	ciphertext.Value[0].Coeffs = ciphertext.Value[0].Coeffs[:levelQ+1]
+	ciphertext.Value[1].Coeffs = ciphertext.Value[1].Coeffs[:levelQ+1]
 }
 
-// Encrypt encrypts the input Plaintext and write the result in ctOut.
-func (encryptor *skEncryptor) Encrypt(plaintext *Plaintext, ciphertext *Ciphertext) {
-	encryptor.uniformSampler.ReadLvl(utils.MinInt(plaintext.Level(), ciphertext.Level()), ciphertext.Value[1])
-	encryptor.encrypt(plaintext, ciphertext)
-}
+func (enc *encryptorBase) encryptSk(plaintext *Plaintext, sk *SecretKey, ciphertext *Ciphertext) {
 
-// EncryptFromCRP encrypts the input Plaintext given the uniformly random element c1 and write the result in ctOut.
-func (encryptor *skEncryptor) EncryptFromCRP(plaintext *Plaintext, crp *ring.Poly, ctOut *Ciphertext) {
-	ring.CopyValues(crp, ctOut.Value[1])
-	encryptor.encrypt(plaintext, ctOut)
-}
-
-func (encryptor *skEncryptor) encrypt(plaintext *Plaintext, ciphertext *Ciphertext) {
-
-	ringQ := encryptor.ringQ
+	ringQ := enc.ringQ
 
 	levelQ := utils.MinInt(plaintext.Level(), ciphertext.Level())
 
-	poolQ0 := encryptor.poolQ[0]
+	poolQ0 := enc.poolQ[0]
 
 	ciphertextNTT := ciphertext.Value[0].IsNTT
 
-	ringQ.MulCoeffsMontgomeryLvl(levelQ, ciphertext.Value[1], encryptor.sk.Value.Q, ciphertext.Value[0])
+	ringQ.MulCoeffsMontgomeryLvl(levelQ, ciphertext.Value[1], sk.Value.Q, ciphertext.Value[0])
 	ringQ.NegLvl(levelQ, ciphertext.Value[0], ciphertext.Value[0])
 
 	if ciphertextNTT {
 
-		encryptor.gaussianSampler.ReadLvl(levelQ, poolQ0)
+		enc.gaussianSampler.ReadLvl(levelQ, poolQ0)
 
 		if plaintext.Value.IsNTT {
 			ringQ.NTTLvl(levelQ, poolQ0, poolQ0)
@@ -281,7 +348,7 @@ func (encryptor *skEncryptor) encrypt(plaintext *Plaintext, ciphertext *Cipherte
 			ringQ.AddLvl(levelQ, ciphertext.Value[0], plaintext.Value, ciphertext.Value[0])
 		}
 
-		encryptor.gaussianSampler.ReadAndAddLvl(ciphertext.Level(), ciphertext.Value[0])
+		enc.gaussianSampler.ReadAndAddLvl(ciphertext.Level(), ciphertext.Value[0])
 
 		ringQ.InvNTTLvl(levelQ, ciphertext.Value[1], ciphertext.Value[1])
 
@@ -292,35 +359,4 @@ func (encryptor *skEncryptor) encrypt(plaintext *Plaintext, ciphertext *Cipherte
 
 	ciphertext.Value[0].Coeffs = ciphertext.Value[0].Coeffs[:levelQ+1]
 	ciphertext.Value[1].Coeffs = ciphertext.Value[1].Coeffs[:levelQ+1]
-}
-
-func newEncryptorBase(params Parameters) encryptorBase {
-
-	ringQ := params.RingQ()
-	ringP := params.RingP()
-
-	prng, err := utils.NewPRNG()
-	if err != nil {
-		panic(err)
-	}
-
-	var poolP [3]*ring.Poly
-	if params.PCount() != 0 {
-		poolP = [3]*ring.Poly{ringP.NewPoly(), ringP.NewPoly(), ringP.NewPoly()}
-	}
-
-	return encryptorBase{
-		params:          params,
-		ringQ:           ringQ,
-		ringP:           ringP,
-		poolQ:           [1]*ring.Poly{ringQ.NewPoly()},
-		poolP:           poolP,
-		gaussianSampler: ring.NewGaussianSampler(prng, ringQ, params.Sigma(), int(6*params.Sigma())),
-		ternarySampler:  ring.NewTernarySampler(prng, ringQ, 0.5, false),
-		uniformSampler:  ring.NewUniformSampler(prng, ringQ),
-	}
-}
-
-func (encryptor *encryptorBase) EncryptFromCRP(plaintext *Plaintext, crp *ring.Poly, ctOut *Ciphertext) {
-	panic("Cannot encrypt with CRP using an encryptor created with the public-key")
 }

--- a/rlwe/encryptor.go
+++ b/rlwe/encryptor.go
@@ -64,7 +64,7 @@ func NewEncryptor(params Parameters, key interface{}) Encryptor {
 		enc := newEncryptor(params)
 		return &enc
 	default:
-		panic("key must be either rlwe.PublicKey or rlwe.SecretKey")
+		panic("key must be either *rlwe.PublicKey, *rlwe.SecretKey or nil")
 	}
 }
 
@@ -188,7 +188,7 @@ func (enc *encryptor) SetKey(key interface{}) Encryptor {
 		}
 		return &skEncryptor{*enc, key}
 	default:
-		panic("key must be either rlwe.PublicKey or rlwe.SecretKey")
+		panic("key must be either *rlwe.PublicKey or *rlwe.SecretKey")
 	}
 }
 

--- a/rlwe/encryptor.go
+++ b/rlwe/encryptor.go
@@ -23,10 +23,6 @@ type Encryptor interface {
 	// WithKey creates a shallow copy of the receiver Encryptor with the provided key.
 	// This is equivalent to calling Encryptor.ShallowCopy().SetKey(*)
 	WithKey(key interface{}) Encryptor
-
-	// SetKey sets the key of the target encryptor. Either secret-key, public-key or nil can be passed as argument.
-	// Will wrap the target Encryptor to a pkEncryptor (public-key) or skEncrytor (secret-key).
-	SetKey(key interface{}) Encryptor
 }
 
 type pkEncryptor struct {
@@ -156,26 +152,26 @@ func (enc *encryptor) ShallowCopy() Encryptor {
 }
 
 func (enc *pkEncryptor) WithKey(key interface{}) Encryptor {
-	return enc.ShallowCopy().SetKey(key)
+	return enc.ShallowCopy().(*pkEncryptor).setKey(key)
 }
 
 func (enc *skEncryptor) WithKey(key interface{}) Encryptor {
-	return enc.ShallowCopy().SetKey(key)
+	return enc.ShallowCopy().(*skEncryptor).setKey(key)
 }
 
 func (enc *encryptor) WithKey(key interface{}) Encryptor {
-	return enc.ShallowCopy().SetKey(key)
+	return enc.ShallowCopy().(*encryptor).setKey(key)
 }
 
-func (enc *pkEncryptor) SetKey(key interface{}) Encryptor {
-	return enc.encryptor.SetKey(key)
+func (enc *pkEncryptor) setKey(key interface{}) Encryptor {
+	return enc.encryptor.setKey(key)
 }
 
-func (enc *skEncryptor) SetKey(key interface{}) Encryptor {
-	return enc.encryptor.SetKey(key)
+func (enc *skEncryptor) setKey(key interface{}) Encryptor {
+	return enc.encryptor.setKey(key)
 }
 
-func (enc *encryptor) SetKey(key interface{}) Encryptor {
+func (enc *encryptor) setKey(key interface{}) Encryptor {
 	switch key := key.(type) {
 	case *PublicKey:
 		if key.Value[0].Q.Degree() != enc.params.N() || key.Value[1].Q.Degree() != enc.params.N() {

--- a/rlwe/encryptor.go
+++ b/rlwe/encryptor.go
@@ -31,7 +31,7 @@ type skEncryptor struct {
 }
 
 // NewEncryptor creates a new Encryptor
-// Accepts either a secret-key or a public-key
+// Accepts either a secret-key or a public-key.
 func NewEncryptor(params Parameters, key interface{}) Encryptor {
 	enc := newEncryptor(params)
 	return enc.setKey(key)
@@ -101,12 +101,12 @@ func newEncryptorBuffers(params Parameters) *encryptorBuffers {
 	}
 }
 
-// Encrypt encrypts the input plaintext using the stored public-key and write the result on ct.
+// Encrypt encrypts the input plaintext using the stored public-key and writes the result on ct.
 // The encryption procedure first samples an new encryption of zero under the public-key and
 // then adds the plaintext.
 // The encryption procedures depends on the parameters. If the auxiliary modulus P is defined,
-// then the encryption of zero is sampled in QP before being rescaled by P, else it is directly
-// samples in Q.
+// then the encryption of zero is sampled in QP before being rescaled by P; otherwise, it is directly
+// sampled in Q.
 func (enc *pkEncryptor) Encrypt(pt *Plaintext, ct *Ciphertext) {
 	enc.uniformSampler.ReadLvl(utils.MinInt(pt.Level(), ct.Level()), ct.Value[1])
 
@@ -381,15 +381,15 @@ func (enc *encryptor) setKey(key interface{}) Encryptor {
 	switch key := key.(type) {
 	case *PublicKey:
 		if key.Value[0].Q.Degree() != enc.params.N() || key.Value[1].Q.Degree() != enc.params.N() {
-			panic("cannot newEncryptor: pk ring degree does not match params ring degree")
+			panic("cannot setKey: pk ring degree does not match params ring degree")
 		}
 		return &pkEncryptor{*enc, key}
 	case *SecretKey:
 		if key.Value.Q.Degree() != enc.params.N() {
-			panic("cannot newEncryptor: sk ring degree does not match params ring degree")
+			panic("cannot setKey: sk ring degree does not match params ring degree")
 		}
 		return &skEncryptor{*enc, key}
 	default:
-		panic("key must be either *rlwe.PublicKey or *rlwe.SecretKey")
+		panic("cannot setKey: key must be either *rlwe.PublicKey or *rlwe.SecretKey")
 	}
 }

--- a/rlwe/encryptor.go
+++ b/rlwe/encryptor.go
@@ -21,7 +21,7 @@ type Encryptor interface {
 	ShallowCopy() Encryptor
 
 	// WithKey creates a shallow copy of the receiver Encryptor with the provided key.
-	// This is equivalent to calling Encryptor.ShallowCopy().WithKey(*)
+	// This is equivalent to calling Encryptor.ShallowCopy().SetKey(*)
 	WithKey(key interface{}) Encryptor
 
 	// SetKey sets the key of the target encryptor. Either secret-key, public-key or nil can be passed as argument.

--- a/rlwe/keygen.go
+++ b/rlwe/keygen.go
@@ -48,13 +48,20 @@ func NewKeyGenerator(params Parameters) KeyGenerator {
 		panic(err)
 	}
 
+	var poolQP PolyQP
+	var uniformSamplerP *ring.UniformSampler
+	if params.PCount() > 0 {
+		poolQP = params.RingQP().NewPoly()
+		uniformSamplerP = ring.NewUniformSampler(prng, params.RingP())
+	}
+
 	return &keyGenerator{
 		params:           params,
 		poolQ:            params.RingQ().NewPoly(),
-		poolQP:           params.RingQP().NewPoly(),
+		poolQP:           poolQP,
 		gaussianSamplerQ: ring.NewGaussianSampler(prng, params.RingQ(), params.Sigma(), int(6*params.Sigma())),
 		uniformSamplerQ:  ring.NewUniformSampler(prng, params.RingQ()),
-		uniformSamplerP:  ring.NewUniformSampler(prng, params.RingP()),
+		uniformSamplerP:  uniformSamplerP,
 	}
 }
 
@@ -88,24 +95,64 @@ func (keygen *keyGenerator) GenSecretKeySparse(hw int) (sk *SecretKey) {
 	return keygen.genSecretKeyFromSampler(ternarySamplerMontgomery)
 }
 
+// genSecretKeyFromSampler generates a new SecretKey sampled from the provided Sampler.
+func (keygen *keyGenerator) genSecretKeyFromSampler(sampler ring.Sampler) (sk *SecretKey) {
+	sk = new(SecretKey)
+	if keygen.params.PCount() > 0 {
+		ringQP := keygen.params.RingQP()
+		sk.Value = ringQP.NewPoly()
+		levelQ, levelP := keygen.params.QCount()-1, keygen.params.PCount()-1
+		sampler.Read(sk.Value.Q)
+		ringQP.ExtendBasisSmallNormAndCenter(sk.Value.Q, levelP, nil, sk.Value.P)
+		ringQP.NTTLvl(levelQ, levelP, sk.Value, sk.Value)
+		ringQP.MFormLvl(levelQ, levelP, sk.Value, sk.Value)
+	} else {
+		ringQ := keygen.params.RingQ()
+		sk = new(SecretKey)
+		sk.Value.Q = ringQ.NewPoly()
+		sampler.Read(sk.Value.Q)
+		ringQ.NTT(sk.Value.Q, sk.Value.Q)
+		ringQ.MForm(sk.Value.Q, sk.Value.Q)
+	}
+
+	return
+}
+
 // GenPublicKey generates a new public key from the provided SecretKey.
 func (keygen *keyGenerator) GenPublicKey(sk *SecretKey) (pk *PublicKey) {
 
 	pk = new(PublicKey)
-	ringQP := keygen.params.RingQP()
-	levelQ, levelP := keygen.params.QCount()-1, keygen.params.PCount()-1
 
-	//pk[0] = [-as + e]
-	//pk[1] = [a]
-	pk = NewPublicKey(keygen.params)
-	keygen.gaussianSamplerQ.Read(pk.Value[0].Q)
-	ringQP.ExtendBasisSmallNormAndCenter(pk.Value[0].Q, levelP, nil, pk.Value[0].P)
-	ringQP.NTTLvl(levelQ, levelP, pk.Value[0], pk.Value[0])
+	if keygen.params.PCount() > 0 {
 
-	keygen.uniformSamplerQ.Read(pk.Value[1].Q)
-	keygen.uniformSamplerP.Read(pk.Value[1].P)
+		ringQP := keygen.params.RingQP()
+		levelQ, levelP := keygen.params.QCount()-1, keygen.params.PCount()-1
 
-	ringQP.MulCoeffsMontgomeryAndSubLvl(levelQ, levelP, sk.Value, pk.Value[1], pk.Value[0])
+		//pk[0] = [-as + e]
+		//pk[1] = [a]
+		pk = NewPublicKey(keygen.params)
+		keygen.gaussianSamplerQ.Read(pk.Value[0].Q)
+		ringQP.ExtendBasisSmallNormAndCenter(pk.Value[0].Q, levelP, nil, pk.Value[0].P)
+		ringQP.NTTLvl(levelQ, levelP, pk.Value[0], pk.Value[0])
+
+		keygen.uniformSamplerQ.Read(pk.Value[1].Q)
+		keygen.uniformSamplerP.Read(pk.Value[1].P)
+
+		ringQP.MulCoeffsMontgomeryAndSubLvl(levelQ, levelP, sk.Value, pk.Value[1], pk.Value[0])
+	} else {
+		ringQ := keygen.params.RingQ()
+
+		//pk[0] = [-as + e]
+		//pk[1] = [a]
+		pk = NewPublicKey(keygen.params)
+		keygen.gaussianSamplerQ.Read(pk.Value[0].Q)
+
+		ringQ.NTT(pk.Value[0].Q, pk.Value[0].Q)
+
+		keygen.uniformSamplerQ.Read(pk.Value[1].Q)
+
+		ringQ.MulCoeffsMontgomeryAndSub(sk.Value.Q, pk.Value[1].Q, pk.Value[0].Q)
+	}
 	return pk
 }
 
@@ -282,19 +329,6 @@ func (keygen *keyGenerator) GenSwitchingKey(skInput, skOutput *SecretKey) (swk *
 	}
 
 	return
-}
-
-// genSecretKeyFromSampler generates a new SecretKey sampled from the provided Sampler.
-func (keygen *keyGenerator) genSecretKeyFromSampler(sampler ring.Sampler) *SecretKey {
-	ringQP := keygen.params.RingQP()
-	sk := new(SecretKey)
-	sk.Value = ringQP.NewPoly()
-	levelQ, levelP := keygen.params.QCount()-1, keygen.params.PCount()-1
-	sampler.Read(sk.Value.Q)
-	ringQP.ExtendBasisSmallNormAndCenter(sk.Value.Q, levelP, nil, sk.Value.P)
-	ringQP.NTTLvl(levelQ, levelP, sk.Value, sk.Value)
-	ringQP.MFormLvl(levelQ, levelP, sk.Value, sk.Value)
-	return sk
 }
 
 func (keygen *keyGenerator) genSwitchingKey(skIn *ring.Poly, skOut PolyQP, swk *SwitchingKey) {

--- a/rlwe/keyswitch.go
+++ b/rlwe/keyswitch.go
@@ -10,7 +10,7 @@ import (
 type KeySwitcher struct {
 	*Parameters
 	*keySwitcherBuffer
-	Baseconverter *ring.FastBasisExtender
+	BasisExtender *ring.BasisExtender
 	Decomposer    *ring.Decomposer
 }
 
@@ -44,7 +44,7 @@ func newKeySwitcherBuffer(params Parameters) *keySwitcherBuffer {
 func NewKeySwitcher(params Parameters) *KeySwitcher {
 	ks := new(KeySwitcher)
 	ks.Parameters = &params
-	ks.Baseconverter = ring.NewFastBasisExtender(params.RingQ(), params.RingP())
+	ks.BasisExtender = ring.NewBasisExtender(params.RingQ(), params.RingP())
 	ks.Decomposer = ring.NewDecomposer(params.RingQ(), params.RingP())
 	ks.keySwitcherBuffer = newKeySwitcherBuffer(params)
 	return ks
@@ -56,7 +56,7 @@ func (ks *KeySwitcher) ShallowCopy() *KeySwitcher {
 		Parameters:        ks.Parameters,
 		Decomposer:        ks.Decomposer,
 		keySwitcherBuffer: newKeySwitcherBuffer(*ks.Parameters),
-		Baseconverter:     ks.Baseconverter.ShallowCopy(),
+		BasisExtender:     ks.BasisExtender.ShallowCopy(),
 	}
 }
 
@@ -68,8 +68,8 @@ func (ks *KeySwitcher) SwitchKeysInPlace(levelQ int, cx *ring.Poly, evakey *Swit
 	levelP := len(evakey.Value[0][0].P.Coeffs) - 1
 
 	if cx.IsNTT {
-		ks.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, p0, ks.Pool[1].P, p0)
-		ks.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, p1, ks.Pool[2].P, p1)
+		ks.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, p0, ks.Pool[1].P, p0)
+		ks.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, p1, ks.Pool[2].P, p1)
 	} else {
 
 		ks.ringQ.InvNTTLazyLvl(levelQ, p0, p0)
@@ -77,8 +77,8 @@ func (ks *KeySwitcher) SwitchKeysInPlace(levelQ int, cx *ring.Poly, evakey *Swit
 		ks.ringP.InvNTTLazyLvl(levelP, ks.Pool[1].P, ks.Pool[1].P)
 		ks.ringP.InvNTTLazyLvl(levelP, ks.Pool[2].P, ks.Pool[2].P)
 
-		ks.Baseconverter.ModDownQPtoQ(levelQ, levelP, p0, ks.Pool[1].P, p0)
-		ks.Baseconverter.ModDownQPtoQ(levelQ, levelP, p1, ks.Pool[2].P, p1)
+		ks.BasisExtender.ModDownQPtoQ(levelQ, levelP, p0, ks.Pool[1].P, p0)
+		ks.BasisExtender.ModDownQPtoQ(levelQ, levelP, p1, ks.Pool[2].P, p1)
 	}
 }
 
@@ -222,8 +222,8 @@ func (ks *KeySwitcher) KeyswitchHoisted(levelQ int, PoolDecompQP []PolyQP, evake
 	levelP := len(evakey.Value[0][0].P.Coeffs) - 1
 
 	// Computes c0Q = c0Q/c0P and c1Q = c1Q/c1P
-	ks.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, c0Q, c0P, c0Q)
-	ks.Baseconverter.ModDownQPtoQNTT(levelQ, levelP, c1Q, c1P, c1Q)
+	ks.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, c0Q, c0P, c0Q)
+	ks.BasisExtender.ModDownQPtoQNTT(levelQ, levelP, c1Q, c1P, c1Q)
 }
 
 // KeyswitchHoistedNoModDown applies the key-switch to the decomposed polynomial c2 mod QP (PoolDecompQ and PoolDecompP)

--- a/rlwe/params.go
+++ b/rlwe/params.go
@@ -53,63 +53,8 @@ type Parameters struct {
 	sigma    float64
 	ringQ    *ring.Ring
 	ringP    *ring.Ring
-<<<<<<< HEAD
 	ringType ring.Type
 }
-=======
-	ringType RingType
-}
-
-var (
-	// TestPN11QP54 is a set of default parameters with logN=11 and logQP=54
-	TestPN11QP54 = ParametersLiteral{
-		LogN:     11,
-		Q:        []uint64{0x3fffffffef8001},
-		P:        []uint64{},
-		Sigma:    DefaultSigma,
-		RingType: RingStandard,
-	}
-
-	// TestPN12QP109 is a set of default parameters with logN=12 and logQP=109
-	TestPN12QP109 = ParametersLiteral{
-		LogN:     12,
-		Q:        []uint64{0xffffc4001, 0x100008c001}, // 36 + 36 bits
-		P:        []uint64{0x1000090001},              // 36 bits
-		Sigma:    DefaultSigma,
-		RingType: RingStandard,
-	}
-	// TestPN13QP218 is a set of default parameters with logN=13 and logQP=218
-	TestPN13QP218 = ParametersLiteral{
-		LogN:     13,
-		Q:        []uint64{0x3fffffffef8001, 0x40000000120001, 0x3fffffffeb8001}, // 54 + 54 + 54 bits
-		P:        []uint64{0x80000000068001},                                     // 55 bits
-		Sigma:    DefaultSigma,
-		RingType: RingStandard,
-	}
-
-	// TestPN14QP438 is a set of default parameters with logN=14 and logQP=438
-	TestPN14QP438 = ParametersLiteral{
-		LogN: 14,
-		Q: []uint64{0x100000000060001, 0x80000000080001, 0x80000000130001,
-			0x40000000120001, 0x400000001d0001, 0x3fffffffd60001}, // 56 + 55 + 55 + 54 + 54 + 54 bits
-		P:        []uint64{0x7fffffffe90001, 0x80000000190001}, // 55 + 55 bits
-		Sigma:    DefaultSigma,
-		RingType: RingStandard,
-	}
-
-	// TestPN15QP880 is a set of default parameters with logN=15 and logQP=880
-	TestPN15QP880 = ParametersLiteral{
-		LogN: 15,
-		Q: []uint64{0x7ffffffffcc0001, 0x7ffffffffba0001, 0x8000000004a0001, // 59 + 59 + 59 bits
-			0x400000000360001, 0x3ffffffffbe0001, 0x400000000660001, // 58 + 58 + 58 bits
-			0x4000000008a0001, 0x400000000920001, 0x400000000980001, // 58 + 58 + 58 bits
-			0x400000000a40001, 0x400000000c00001, 0x3ffffffff3a0001}, // 58 + 58 + 58 bits
-		P:        []uint64{0xffffffffffc0001, 0x10000000006e0001, 0xfffffffff840001}, // 60 + 60 + 60 bits
-		Sigma:    DefaultSigma,
-		RingType: RingStandard,
-	}
-)
->>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 
 // NewParameters returns a new set of generic RLWE parameters from the given ring degree logn, moduli q and p, and
 // error distribution parameter sigma. It returns the empty parameters Parameters{} and a non-nil error if the

--- a/rlwe/params.go
+++ b/rlwe/params.go
@@ -53,8 +53,63 @@ type Parameters struct {
 	sigma    float64
 	ringQ    *ring.Ring
 	ringP    *ring.Ring
+<<<<<<< HEAD
 	ringType ring.Type
 }
+=======
+	ringType RingType
+}
+
+var (
+	// TestPN11QP54 is a set of default parameters with logN=11 and logQP=54
+	TestPN11QP54 = ParametersLiteral{
+		LogN:     11,
+		Q:        []uint64{0x3fffffffef8001},
+		P:        []uint64{},
+		Sigma:    DefaultSigma,
+		RingType: RingStandard,
+	}
+
+	// TestPN12QP109 is a set of default parameters with logN=12 and logQP=109
+	TestPN12QP109 = ParametersLiteral{
+		LogN:     12,
+		Q:        []uint64{0xffffc4001, 0x100008c001}, // 36 + 36 bits
+		P:        []uint64{0x1000090001},              // 36 bits
+		Sigma:    DefaultSigma,
+		RingType: RingStandard,
+	}
+	// TestPN13QP218 is a set of default parameters with logN=13 and logQP=218
+	TestPN13QP218 = ParametersLiteral{
+		LogN:     13,
+		Q:        []uint64{0x3fffffffef8001, 0x40000000120001, 0x3fffffffeb8001}, // 54 + 54 + 54 bits
+		P:        []uint64{0x80000000068001},                                     // 55 bits
+		Sigma:    DefaultSigma,
+		RingType: RingStandard,
+	}
+
+	// TestPN14QP438 is a set of default parameters with logN=14 and logQP=438
+	TestPN14QP438 = ParametersLiteral{
+		LogN: 14,
+		Q: []uint64{0x100000000060001, 0x80000000080001, 0x80000000130001,
+			0x40000000120001, 0x400000001d0001, 0x3fffffffd60001}, // 56 + 55 + 55 + 54 + 54 + 54 bits
+		P:        []uint64{0x7fffffffe90001, 0x80000000190001}, // 55 + 55 bits
+		Sigma:    DefaultSigma,
+		RingType: RingStandard,
+	}
+
+	// TestPN15QP880 is a set of default parameters with logN=15 and logQP=880
+	TestPN15QP880 = ParametersLiteral{
+		LogN: 15,
+		Q: []uint64{0x7ffffffffcc0001, 0x7ffffffffba0001, 0x8000000004a0001, // 59 + 59 + 59 bits
+			0x400000000360001, 0x3ffffffffbe0001, 0x400000000660001, // 58 + 58 + 58 bits
+			0x4000000008a0001, 0x400000000920001, 0x400000000980001, // 58 + 58 + 58 bits
+			0x400000000a40001, 0x400000000c00001, 0x3ffffffff3a0001}, // 58 + 58 + 58 bits
+		P:        []uint64{0xffffffffffc0001, 0x10000000006e0001, 0xfffffffff840001}, // 60 + 60 + 60 bits
+		Sigma:    DefaultSigma,
+		RingType: RingStandard,
+	}
+)
+>>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 
 // NewParameters returns a new set of generic RLWE parameters from the given ring degree logn, moduli q and p, and
 // error distribution parameter sigma. It returns the empty parameters Parameters{} and a non-nil error if the

--- a/rlwe/rlwe_test.go
+++ b/rlwe/rlwe_test.go
@@ -362,7 +362,7 @@ func testKeySwitcher(kgen KeyGenerator, t *testing.T) {
 				coeffsBigintWant[i] = new(big.Int)
 			}
 
-			ringQ.PolyToBigintCenteredLvl(ciphertext.Level(), c2InvNTT, coeffsBigintRef)
+			ringQ.PolyToBigintCenteredLvl(ciphertext.Level(), c2InvNTT, 1, coeffsBigintRef)
 
 			tmpQ := ringQ.NewPolyLvl(ciphertext.Level())
 			tmpP := ringP.NewPolyLvl(levelP)
@@ -388,8 +388,8 @@ func testKeySwitcher(kgen KeyGenerator, t *testing.T) {
 				ringQ.InvNTTLvl(levelQ, ks.PoolDecompQP[i].Q, tmpQ)
 				ringP.InvNTTLvl(levelP, ks.PoolDecompQP[i].P, tmpP)
 
-				ringQ.PolyToBigintCenteredLvl(levelQ, tmpQ, coeffsBigintHaveQ)
-				ringP.PolyToBigintCenteredLvl(levelP, tmpP, coeffsBigintHaveP)
+				ringQ.PolyToBigintCenteredLvl(levelQ, tmpQ, 1, coeffsBigintHaveQ)
+				ringP.PolyToBigintCenteredLvl(levelP, tmpP, 1, coeffsBigintHaveP)
 
 				// Checks that Reconstruct(NTT(c2 mod Q)) mod q_alpha_i == Reconstruct(NTT(Decomp(c2 mod Q, q_alpha-i) mod QP))
 				for i := range coeffsBigintWant[:1] {

--- a/rlwe/rlwe_test.go
+++ b/rlwe/rlwe_test.go
@@ -20,7 +20,11 @@ import (
 var flagParamString = flag.String("params", "", "specify the test cryptographic parameters as a JSON string. Overrides -short and -long.")
 
 // TestParams is a set of test parameters for the correctness of the rlwe pacakge.
+<<<<<<< HEAD
 var TestParams = []ParametersLiteral{TestPN12QP109, TestPN13QP218, TestPN14QP438, TestPN15QP880, TestPN16QP240, TestPN17QP360}
+=======
+var TestParams = []ParametersLiteral{TestPN11QP54, TestPN12QP109, TestPN13QP218, TestPN14QP438, TestPN15QP880}
+>>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 
 func testString(params Parameters, opname string) string {
 	return fmt.Sprintf("%s/logN=%d/logQ=%d/logP=%d/#Qi=%d/#Pi=%d",
@@ -141,13 +145,22 @@ func testGenKeyPair(kgen KeyGenerator, t *testing.T) {
 		sk, pk := kgen.GenKeyPair()
 
 		// [-as + e] + [as]
-		params.RingQP().MulCoeffsMontgomeryAndAddLvl(sk.Value.Q.Level(), sk.Value.P.Level(), sk.Value, pk.Value[1], pk.Value[0])
-		params.RingQP().InvNTTLvl(sk.Value.Q.Level(), sk.Value.P.Level(), pk.Value[0], pk.Value[0])
+		if params.PCount() > 0 {
 
-		log2Bound := bits.Len64(uint64(math.Floor(DefaultSigma*6)) * uint64(params.N()))
-		require.GreaterOrEqual(t, log2Bound, log2OfInnerSum(pk.Value[0].Q.Level(), params.RingQ(), pk.Value[0].Q))
+			params.RingQP().MulCoeffsMontgomeryAndAddLvl(sk.Value.Q.Level(), sk.Value.P.Level(), sk.Value, pk.Value[1], pk.Value[0])
+			params.RingQP().InvNTTLvl(sk.Value.Q.Level(), sk.Value.P.Level(), pk.Value[0], pk.Value[0])
 
-		require.GreaterOrEqual(t, log2Bound, log2OfInnerSum(pk.Value[0].P.Level(), params.RingP(), pk.Value[0].P))
+			log2Bound := bits.Len64(uint64(math.Floor(DefaultSigma*6)) * uint64(params.N()))
+			require.GreaterOrEqual(t, log2Bound, log2OfInnerSum(pk.Value[0].Q.Level(), params.RingQ(), pk.Value[0].Q))
+			require.GreaterOrEqual(t, log2Bound, log2OfInnerSum(pk.Value[0].P.Level(), params.RingP(), pk.Value[0].P))
+		} else {
+			params.RingQ().MulCoeffsMontgomeryAndAdd(sk.Value.Q, pk.Value[1].Q, pk.Value[0].Q)
+			params.RingQ().InvNTT(pk.Value[0].Q, pk.Value[0].Q)
+
+			log2Bound := bits.Len64(uint64(math.Floor(DefaultSigma*6)) * uint64(params.N()))
+			require.GreaterOrEqual(t, log2Bound, log2OfInnerSum(pk.Value[0].Q.Level(), params.RingQ(), pk.Value[0].Q))
+		}
+
 	})
 }
 
@@ -161,6 +174,10 @@ func testSwitchKeyGen(kgen KeyGenerator, t *testing.T) {
 	// 2) Reconstructing the key
 	// 3) Checking that the difference with the input key has a small norm
 	t.Run(testString(params, "SWKGen/"), func(t *testing.T) {
+
+		if params.PCount() == 0 {
+			t.Skip("#Pi is empty")
+		}
 
 		ringQ := params.RingQ()
 		ringP := params.RingP()
@@ -214,6 +231,7 @@ func testEncryptor(kgen KeyGenerator, t *testing.T) {
 
 	ringQ := params.RingQ()
 
+<<<<<<< HEAD
 	t.Run(testString(params, "Encrypt/Pk/Fast/MaxLevel"), func(t *testing.T) {
 		plaintext := NewPlaintext(params, params.MaxLevel())
 		plaintext.Value.IsNTT = true
@@ -242,6 +260,9 @@ func testEncryptor(kgen KeyGenerator, t *testing.T) {
 		if params.PCount() == 0 {
 			t.Skip()
 		}
+=======
+	t.Run(testString(params, "Encrypt/Pk/MaxLevel/"), func(t *testing.T) {
+>>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 		plaintext := NewPlaintext(params, params.MaxLevel())
 		plaintext.Value.IsNTT = true
 		encryptor := NewEncryptor(params, pk)
@@ -253,10 +274,14 @@ func testEncryptor(kgen KeyGenerator, t *testing.T) {
 		require.GreaterOrEqual(t, 9+params.LogN(), log2OfInnerSum(ciphertext.Level(), ringQ, ciphertext.Value[0]))
 	})
 
+<<<<<<< HEAD
 	t.Run(testString(params, "Encrypt/Pk/Slow/MinLevel"), func(t *testing.T) {
 		if params.PCount() == 0 {
 			t.Skip()
 		}
+=======
+	t.Run(testString(params, "Encrypt/Pk/MinLevel/"), func(t *testing.T) {
+>>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 		plaintext := NewPlaintext(params, 0)
 		plaintext.Value.IsNTT = true
 		encryptor := NewEncryptor(params, pk)
@@ -326,27 +351,25 @@ func testDecryptor(kgen KeyGenerator, t *testing.T) {
 func testKeySwitcher(kgen KeyGenerator, t *testing.T) {
 
 	params := kgen.(*keyGenerator).params
-	sk := kgen.GenSecretKey()
-	skOut := kgen.GenSecretKey()
-	ks := NewKeySwitcher(params)
 
-	ringQ := params.RingQ()
-	ringP := params.RingP()
+	t.Run(testString(params, "KeySwitch/"), func(t *testing.T) {
 
-	levelQ := params.MaxLevel()
-	alpha := params.PCount()
-	levelP := alpha - 1
+		if params.PCount() == 0 {
+			t.Skip("#Pi is empty")
+		}
 
-	QBig := ring.NewUint(1)
-	for i := range ringQ.Modulus[:levelQ+1] {
-		QBig.Mul(QBig, ring.NewUint(ringQ.Modulus[i]))
-	}
+		sk := kgen.GenSecretKey()
+		skOut := kgen.GenSecretKey()
+		ks := NewKeySwitcher(params)
 
-	PBig := ring.NewUint(1)
-	for i := range ringP.Modulus[:levelP+1] {
-		PBig.Mul(PBig, ring.NewUint(ringP.Modulus[i]))
-	}
+		ringQ := params.RingQ()
+		ringP := params.RingP()
 
+		levelQ := params.MaxLevel()
+		alpha := params.PCount()
+		levelP := alpha - 1
+
+<<<<<<< HEAD
 	plaintext := NewPlaintext(params, levelQ)
 	plaintext.Value.IsNTT = true
 	encryptor := NewEncryptor(params, sk)
@@ -370,54 +393,67 @@ func testKeySwitcher(kgen KeyGenerator, t *testing.T) {
 			coeffsBigintHaveP[i] = new(big.Int)
 			coeffsBigintRef[i] = new(big.Int)
 			coeffsBigintWant[i] = new(big.Int)
+=======
+		QBig := ring.NewUint(1)
+		for i := range ringQ.Modulus[:levelQ+1] {
+			QBig.Mul(QBig, ring.NewUint(ringQ.Modulus[i]))
+>>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 		}
 
-		ringQ.PolyToBigintCenteredLvl(ciphertext.Level(), c2InvNTT, coeffsBigintRef)
+		PBig := ring.NewUint(1)
+		for i := range ringP.Modulus[:levelP+1] {
+			PBig.Mul(PBig, ring.NewUint(ringP.Modulus[i]))
+		}
 
-		tmpQ := ringQ.NewPolyLvl(ciphertext.Level())
-		tmpP := ringP.NewPolyLvl(levelP)
+		plaintext := NewPlaintext(params, levelQ)
+		plaintext.Value.IsNTT = true
+		encryptor := NewEncryptor(params, sk)
+		ciphertext := NewCiphertextNTT(params, 1, plaintext.Level())
+		encryptor.Encrypt(plaintext, ciphertext)
 
-		for i := 0; i < len(ks.PoolDecompQP); i++ {
+		// Tests that a random polynomial decomposed is equal to its
+		// reconstruction mod each RNS
+		t.Run(testString(params, "DecomposeNTT/"), func(t *testing.T) {
 
-			ks.DecomposeSingleNTT(levelQ, levelP, alpha, i, ciphertext.Value[1], c2InvNTT, ks.PoolDecompQP[i].Q, ks.PoolDecompQP[i].P)
+			c2InvNTT := ringQ.NewPolyLvl(ciphertext.Level())
+			ringQ.InvNTT(ciphertext.Value[1], c2InvNTT)
 
-			// Compute q_alpha_i in bigInt
-			qalphai := ring.NewInt(1)
+			coeffsBigintHaveQ := make([]*big.Int, ringQ.N)
+			coeffsBigintHaveP := make([]*big.Int, ringQ.N)
+			coeffsBigintRef := make([]*big.Int, ringQ.N)
+			coeffsBigintWant := make([]*big.Int, ringQ.N)
 
-			for j := 0; j < alpha; j++ {
-				idx := i*alpha + j
-				if idx > levelQ {
-					break
+			for i := range coeffsBigintRef {
+				coeffsBigintHaveQ[i] = new(big.Int)
+				coeffsBigintHaveP[i] = new(big.Int)
+				coeffsBigintRef[i] = new(big.Int)
+				coeffsBigintWant[i] = new(big.Int)
+			}
+
+			ringQ.PolyToBigintCenteredLvl(ciphertext.Level(), c2InvNTT, coeffsBigintRef)
+
+			tmpQ := ringQ.NewPolyLvl(ciphertext.Level())
+			tmpP := ringP.NewPolyLvl(levelP)
+
+			for i := 0; i < len(ks.PoolDecompQP); i++ {
+
+				ks.DecomposeSingleNTT(levelQ, levelP, alpha, i, ciphertext.Value[1], c2InvNTT, ks.PoolDecompQP[i].Q, ks.PoolDecompQP[i].P)
+
+				// Compute q_alpha_i in bigInt
+				qalphai := ring.NewInt(1)
+
+				for j := 0; j < alpha; j++ {
+					idx := i*alpha + j
+					if idx > levelQ {
+						break
+					}
+					qalphai.Mul(qalphai, ring.NewUint(ringQ.Modulus[idx]))
 				}
-				qalphai.Mul(qalphai, ring.NewUint(ringQ.Modulus[idx]))
-			}
 
-			ringQ.ReduceLvl(levelQ, ks.PoolDecompQP[i].Q, ks.PoolDecompQP[i].Q)
-			ringP.ReduceLvl(levelP, ks.PoolDecompQP[i].P, ks.PoolDecompQP[i].P)
+				ringQ.ReduceLvl(levelQ, ks.PoolDecompQP[i].Q, ks.PoolDecompQP[i].Q)
+				ringP.ReduceLvl(levelP, ks.PoolDecompQP[i].P, ks.PoolDecompQP[i].P)
 
-			ringQ.InvNTTLvl(levelQ, ks.PoolDecompQP[i].Q, tmpQ)
-			ringP.InvNTTLvl(levelP, ks.PoolDecompQP[i].P, tmpP)
-
-			ringQ.PolyToBigintCenteredLvl(levelQ, tmpQ, coeffsBigintHaveQ)
-			ringP.PolyToBigintCenteredLvl(levelP, tmpP, coeffsBigintHaveP)
-
-			// Checks that Reconstruct(NTT(c2 mod Q)) mod q_alpha_i == Reconstruct(NTT(Decomp(c2 mod Q, q_alpha-i) mod QP))
-			for i := range coeffsBigintWant[:1] {
-
-				coeffsBigintWant[i].Mod(coeffsBigintRef[i], qalphai)
-				coeffsBigintWant[i].Mod(coeffsBigintWant[i], QBig)
-				coeffsBigintHaveQ[i].Mod(coeffsBigintHaveQ[i], QBig)
-				require.Equal(t, coeffsBigintHaveQ[i].Cmp(coeffsBigintWant[i]), 0)
-
-				coeffsBigintWant[i].Mod(coeffsBigintRef[i], qalphai)
-				coeffsBigintWant[i].Mod(coeffsBigintWant[i], PBig)
-				coeffsBigintHaveP[i].Mod(coeffsBigintHaveP[i], PBig)
-				require.Equal(t, coeffsBigintHaveP[i].Cmp(coeffsBigintWant[i]), 0)
-
-			}
-		}
-	})
-
+<<<<<<< HEAD
 	// Test that Dec(KS(Enc(ct, sk), skOut), skOut) has a small norm
 	t.Run(testString(params, "KeySwitch/Standard"), func(t *testing.T) {
 		swk := kgen.GenSwitchingKey(sk, skOut)
@@ -427,87 +463,138 @@ func testKeySwitcher(kgen KeyGenerator, t *testing.T) {
 		ringQ.MulCoeffsMontgomeryAndAddLvl(ciphertext.Level(), ciphertext.Value[1], skOut.Value.Q, ciphertext.Value[0])
 		ringQ.InvNTTLvl(ciphertext.Level(), ciphertext.Value[0], ciphertext.Value[0])
 		require.GreaterOrEqual(t, 10+params.LogN(), log2OfInnerSum(ciphertext.Level(), ringQ, ciphertext.Value[0]))
+=======
+				ringQ.InvNTTLvl(levelQ, ks.PoolDecompQP[i].Q, tmpQ)
+				ringP.InvNTTLvl(levelP, ks.PoolDecompQP[i].P, tmpP)
+
+				ringQ.PolyToBigintCenteredLvl(levelQ, tmpQ, coeffsBigintHaveQ)
+				ringP.PolyToBigintCenteredLvl(levelP, tmpP, coeffsBigintHaveP)
+
+				// Checks that Reconstruct(NTT(c2 mod Q)) mod q_alpha_i == Reconstruct(NTT(Decomp(c2 mod Q, q_alpha-i) mod QP))
+				for i := range coeffsBigintWant[:1] {
+
+					coeffsBigintWant[i].Mod(coeffsBigintRef[i], qalphai)
+					coeffsBigintWant[i].Mod(coeffsBigintWant[i], QBig)
+					coeffsBigintHaveQ[i].Mod(coeffsBigintHaveQ[i], QBig)
+					require.Equal(t, coeffsBigintHaveQ[i].Cmp(coeffsBigintWant[i]), 0)
+
+					coeffsBigintWant[i].Mod(coeffsBigintRef[i], qalphai)
+					coeffsBigintWant[i].Mod(coeffsBigintWant[i], PBig)
+					coeffsBigintHaveP[i].Mod(coeffsBigintHaveP[i], PBig)
+					require.Equal(t, coeffsBigintHaveP[i].Cmp(coeffsBigintWant[i]), 0)
+
+				}
+			}
+		})
+
+		// Test that Dec(KS(Enc(ct, sk), skOut), skOut) has a small norm
+		t.Run(testString(params, "KeySwitch/Standard/"), func(t *testing.T) {
+			swk := kgen.GenSwitchingKey(sk, skOut)
+			ks.SwitchKeysInPlace(ciphertext.Value[1].Level(), ciphertext.Value[1], swk, ks.Pool[1].Q, ks.Pool[2].Q)
+			ringQ.Add(ciphertext.Value[0], ks.Pool[1].Q, ciphertext.Value[0])
+			ring.CopyValues(ks.Pool[2].Q, ciphertext.Value[1])
+			ringQ.MulCoeffsMontgomeryAndAddLvl(ciphertext.Level(), ciphertext.Value[1], skOut.Value.Q, ciphertext.Value[0])
+			ringQ.InvNTTLvl(ciphertext.Level(), ciphertext.Value[0], ciphertext.Value[0])
+			require.GreaterOrEqual(t, 10+params.LogN(), log2OfInnerSum(ciphertext.Level(), ringQ, ciphertext.Value[0]))
+		})
+>>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 	})
 }
 
 func testKeySwitchDimension(kgen KeyGenerator, t *testing.T) {
 
 	paramsLargeDim := kgen.(*keyGenerator).params
-	paramsSmallDim, _ := NewParametersFromLiteral(ParametersLiteral{
-		LogN:     paramsLargeDim.LogN() - 1,
-		Q:        paramsLargeDim.Q()[:1],
-		P:        paramsLargeDim.P()[:1],
-		Sigma:    DefaultSigma,
-		RingType: paramsLargeDim.RingType(),
-	})
 
+<<<<<<< HEAD
 	t.Run(testString(paramsLargeDim, "KeySwitchDimension/LargeToSmall"), func(t *testing.T) {
+=======
+	t.Run(testString(paramsLargeDim, "KeySwitchDimension/"), func(t *testing.T) {
+>>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 
-		ringQLargeDim := paramsLargeDim.RingQ()
-		ringQSmallDim := paramsSmallDim.RingQ()
+		if paramsLargeDim.PCount() == 0 {
+			t.Skip("#Pi is empty")
+		}
 
-		kgenLargeDim := NewKeyGenerator(paramsLargeDim)
-		skLargeDim := kgenLargeDim.GenSecretKey()
-		kgenSmallDim := NewKeyGenerator(paramsSmallDim)
-		skSmallDim := kgenSmallDim.GenSecretKey()
+		paramsSmallDim, _ := NewParametersFromLiteral(ParametersLiteral{
+			LogN:     paramsLargeDim.LogN() - 1,
+			Q:        paramsLargeDim.Q()[:1],
+			P:        paramsLargeDim.P()[:1],
+			Sigma:    DefaultSigma,
+			RingType: paramsLargeDim.RingType(),
+		})
 
-		swk := kgenLargeDim.GenSwitchingKey(skLargeDim, skSmallDim)
+		t.Run("LargeToSmall/", func(t *testing.T) {
 
-		plaintext := NewPlaintext(paramsLargeDim, paramsLargeDim.MaxLevel())
-		plaintext.Value.IsNTT = true
-		encryptor := NewEncryptor(paramsLargeDim, skLargeDim)
-		ctLargeDim := NewCiphertextNTT(paramsLargeDim, 1, plaintext.Level())
-		encryptor.Encrypt(plaintext, ctLargeDim)
+			ringQLargeDim := paramsLargeDim.RingQ()
+			ringQSmallDim := paramsSmallDim.RingQ()
 
-		ks := NewKeySwitcher(paramsLargeDim)
-		ks.SwitchKeysInPlace(paramsSmallDim.MaxLevel(), ctLargeDim.Value[1], swk, ks.Pool[1].Q, ks.Pool[2].Q)
-		ringQLargeDim.AddLvl(paramsSmallDim.MaxLevel(), ctLargeDim.Value[0], ks.Pool[1].Q, ctLargeDim.Value[0])
-		ring.CopyValues(ks.Pool[2].Q, ctLargeDim.Value[1])
+			kgenLargeDim := NewKeyGenerator(paramsLargeDim)
+			skLargeDim := kgenLargeDim.GenSecretKey()
+			kgenSmallDim := NewKeyGenerator(paramsSmallDim)
+			skSmallDim := kgenSmallDim.GenSecretKey()
 
-		//Extracts Coefficients
-		ctSmallDim := NewCiphertextNTT(paramsSmallDim, 1, paramsSmallDim.MaxLevel())
+			swk := kgenLargeDim.GenSwitchingKey(skLargeDim, skSmallDim)
 
-		SwitchCiphertextRingDegreeNTT(ctLargeDim, ringQSmallDim, ringQLargeDim, ctSmallDim)
+			plaintext := NewPlaintext(paramsLargeDim, paramsLargeDim.MaxLevel())
+			plaintext.Value.IsNTT = true
+			encryptor := NewEncryptor(paramsLargeDim, skLargeDim)
+			ctLargeDim := NewCiphertextNTT(paramsLargeDim, 1, plaintext.Level())
+			encryptor.Encrypt(plaintext, ctLargeDim)
 
-		// Decrypts with smaller dimension key
-		ringQSmallDim.MulCoeffsMontgomeryAndAddLvl(ctSmallDim.Level(), ctSmallDim.Value[1], skSmallDim.Value.Q, ctSmallDim.Value[0])
-		ringQSmallDim.InvNTTLvl(ctSmallDim.Level(), ctSmallDim.Value[0], ctSmallDim.Value[0])
+			ks := NewKeySwitcher(paramsLargeDim)
+			ks.SwitchKeysInPlace(paramsSmallDim.MaxLevel(), ctLargeDim.Value[1], swk, ks.Pool[1].Q, ks.Pool[2].Q)
+			ringQLargeDim.AddLvl(paramsSmallDim.MaxLevel(), ctLargeDim.Value[0], ks.Pool[1].Q, ctLargeDim.Value[0])
+			ring.CopyValues(ks.Pool[2].Q, ctLargeDim.Value[1])
 
-		require.GreaterOrEqual(t, 10+paramsSmallDim.LogN(), log2OfInnerSum(ctSmallDim.Level(), ringQSmallDim, ctSmallDim.Value[0]))
-	})
+			//Extracts Coefficients
+			ctSmallDim := NewCiphertextNTT(paramsSmallDim, 1, paramsSmallDim.MaxLevel())
 
+<<<<<<< HEAD
 	t.Run(testString(paramsLargeDim, "KeySwitchDimension/SmallToLarge"), func(t *testing.T) {
+=======
+			SwitchCiphertextRingDegreeNTT(ctLargeDim, ringQSmallDim, ringQLargeDim, ctSmallDim)
+>>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 
-		ringQLargeDim := paramsLargeDim.RingQ()
+			// Decrypts with smaller dimension key
+			ringQSmallDim.MulCoeffsMontgomeryAndAddLvl(ctSmallDim.Level(), ctSmallDim.Value[1], skSmallDim.Value.Q, ctSmallDim.Value[0])
+			ringQSmallDim.InvNTTLvl(ctSmallDim.Level(), ctSmallDim.Value[0], ctSmallDim.Value[0])
 
-		kgenLargeDim := NewKeyGenerator(paramsLargeDim)
-		skLargeDim := kgenLargeDim.GenSecretKey()
-		kgenSmallDim := NewKeyGenerator(paramsSmallDim)
-		skSmallDim := kgenSmallDim.GenSecretKey()
+			require.GreaterOrEqual(t, 10+paramsSmallDim.LogN(), log2OfInnerSum(ctSmallDim.Level(), ringQSmallDim, ctSmallDim.Value[0]))
+		})
 
-		swk := kgenLargeDim.GenSwitchingKey(skSmallDim, skLargeDim)
+		t.Run("SmallToLarge/", func(t *testing.T) {
 
-		plaintext := NewPlaintext(paramsSmallDim, paramsSmallDim.MaxLevel())
-		plaintext.Value.IsNTT = true
-		encryptor := NewEncryptor(paramsSmallDim, skSmallDim)
-		ctSmallDim := NewCiphertextNTT(paramsSmallDim, 1, plaintext.Level())
-		encryptor.Encrypt(plaintext, ctSmallDim)
+			ringQLargeDim := paramsLargeDim.RingQ()
 
-		//Extracts Coefficients
-		ctLargeDim := NewCiphertextNTT(paramsLargeDim, 1, plaintext.Level())
+			kgenLargeDim := NewKeyGenerator(paramsLargeDim)
+			skLargeDim := kgenLargeDim.GenSecretKey()
+			kgenSmallDim := NewKeyGenerator(paramsSmallDim)
+			skSmallDim := kgenSmallDim.GenSecretKey()
 
-		SwitchCiphertextRingDegreeNTT(ctSmallDim, nil, nil, ctLargeDim)
+			swk := kgenLargeDim.GenSwitchingKey(skSmallDim, skLargeDim)
 
-		ks := NewKeySwitcher(paramsLargeDim)
-		ks.SwitchKeysInPlace(ctLargeDim.Value[1].Level(), ctLargeDim.Value[1], swk, ks.Pool[1].Q, ks.Pool[2].Q)
-		ringQLargeDim.Add(ctLargeDim.Value[0], ks.Pool[1].Q, ctLargeDim.Value[0])
-		ring.CopyValues(ks.Pool[2].Q, ctLargeDim.Value[1])
+			plaintext := NewPlaintext(paramsSmallDim, paramsSmallDim.MaxLevel())
+			plaintext.Value.IsNTT = true
+			encryptor := NewEncryptor(paramsSmallDim, skSmallDim)
+			ctSmallDim := NewCiphertextNTT(paramsSmallDim, 1, plaintext.Level())
+			encryptor.Encrypt(plaintext, ctSmallDim)
 
-		// Decrypts with smaller dimension key
-		ringQLargeDim.MulCoeffsMontgomeryAndAddLvl(ctLargeDim.Level(), ctLargeDim.Value[1], skLargeDim.Value.Q, ctLargeDim.Value[0])
-		ringQLargeDim.InvNTTLvl(ctLargeDim.Level(), ctLargeDim.Value[0], ctLargeDim.Value[0])
+			//Extracts Coefficients
+			ctLargeDim := NewCiphertextNTT(paramsLargeDim, 1, plaintext.Level())
 
-		require.GreaterOrEqual(t, 10+paramsSmallDim.LogN(), log2OfInnerSum(ctLargeDim.Level(), ringQLargeDim, ctLargeDim.Value[0]))
+			SwitchCiphertextRingDegreeNTT(ctSmallDim, nil, nil, ctLargeDim)
+
+			ks := NewKeySwitcher(paramsLargeDim)
+			ks.SwitchKeysInPlace(ctLargeDim.Value[1].Level(), ctLargeDim.Value[1], swk, ks.Pool[1].Q, ks.Pool[2].Q)
+			ringQLargeDim.Add(ctLargeDim.Value[0], ks.Pool[1].Q, ctLargeDim.Value[0])
+			ring.CopyValues(ks.Pool[2].Q, ctLargeDim.Value[1])
+
+			// Decrypts with smaller dimension key
+			ringQLargeDim.MulCoeffsMontgomeryAndAddLvl(ctLargeDim.Level(), ctLargeDim.Value[1], skLargeDim.Value.Q, ctLargeDim.Value[0])
+			ringQLargeDim.InvNTTLvl(ctLargeDim.Level(), ctLargeDim.Value[0], ctLargeDim.Value[0])
+
+			require.GreaterOrEqual(t, 10+paramsSmallDim.LogN(), log2OfInnerSum(ctLargeDim.Level(), ringQLargeDim, ctLargeDim.Value[0]))
+		})
 	})
 }
 

--- a/rlwe/rlwe_test.go
+++ b/rlwe/rlwe_test.go
@@ -274,6 +274,51 @@ func testEncryptor(kgen KeyGenerator, t *testing.T) {
 		ringQ.InvNTTLvl(ciphertext.Level(), ciphertext.Value[0], ciphertext.Value[0])
 		require.GreaterOrEqual(t, 5+params.LogN(), log2OfInnerSum(ciphertext.Level(), ringQ, ciphertext.Value[0]))
 	})
+
+	t.Run(testString(params, "ShallowCopy/Sk"), func(t *testing.T) {
+		enc1 := NewEncryptor(params, sk)
+		enc2 := enc1.ShallowCopy()
+		skEnc1, skEnc2 := enc1.(*skEncryptor), enc2.(*skEncryptor)
+		require.True(t, skEnc1.encryptorBase == skEnc2.encryptorBase)
+		require.True(t, skEnc1.sk == skEnc2.sk)
+		require.False(t, skEnc1.basisextender == skEnc2.basisextender)
+		require.False(t, skEnc1.encryptorBuffers == skEnc2.encryptorBuffers)
+		require.False(t, skEnc1.encryptorSamplers == skEnc2.encryptorSamplers)
+	})
+
+	t.Run(testString(params, "ShallowCopy/Pk"), func(t *testing.T) {
+		enc1 := NewEncryptor(params, pk)
+		enc2 := enc1.ShallowCopy()
+		pkEnc1, pkEnc2 := enc1.(*pkEncryptor), enc2.(*pkEncryptor)
+		require.True(t, pkEnc1.encryptorBase == pkEnc2.encryptorBase)
+		require.True(t, pkEnc1.pk == pkEnc2.pk)
+		require.False(t, pkEnc1.basisextender == pkEnc2.basisextender)
+		require.False(t, pkEnc1.encryptorBuffers == pkEnc2.encryptorBuffers)
+		require.False(t, pkEnc1.encryptorSamplers == pkEnc2.encryptorSamplers)
+	})
+
+	sk2 := kgen.GenSecretKey()
+
+	t.Run(testString(params, "WithKey/Sk->Sk"), func(t *testing.T) {
+		enc1 := NewEncryptor(params, sk)
+		enc2 := enc1.WithKey(sk2)
+		skEnc1, skEnc2 := enc1.(*skEncryptor), enc2.(*skEncryptor)
+		require.True(t, skEnc1.encryptorBase == skEnc2.encryptorBase)
+		require.False(t, skEnc1.sk == skEnc2.sk)
+		require.False(t, skEnc1.basisextender == skEnc2.basisextender)
+		require.False(t, skEnc1.encryptorBuffers == skEnc2.encryptorBuffers)
+		require.False(t, skEnc1.encryptorSamplers == skEnc2.encryptorSamplers)
+	})
+
+	t.Run(testString(params, "WithKey/Sk->Pk"), func(t *testing.T) {
+		enc1 := NewEncryptor(params, sk)
+		enc2 := enc1.WithKey(pk)
+		skEnc1, pkEnc2 := enc1.(*skEncryptor), enc2.(*pkEncryptor)
+		require.True(t, skEnc1.encryptorBase == pkEnc2.encryptorBase)
+		require.False(t, skEnc1.basisextender == pkEnc2.basisextender)
+		require.False(t, skEnc1.encryptorBuffers == pkEnc2.encryptorBuffers)
+		require.False(t, skEnc1.encryptorSamplers == pkEnc2.encryptorSamplers)
+	})
 }
 
 func testDecryptor(kgen KeyGenerator, t *testing.T) {

--- a/rlwe/rlwe_test.go
+++ b/rlwe/rlwe_test.go
@@ -20,11 +20,7 @@ import (
 var flagParamString = flag.String("params", "", "specify the test cryptographic parameters as a JSON string. Overrides -short and -long.")
 
 // TestParams is a set of test parameters for the correctness of the rlwe pacakge.
-<<<<<<< HEAD
 var TestParams = []ParametersLiteral{TestPN12QP109, TestPN13QP218, TestPN14QP438, TestPN15QP880, TestPN16QP240, TestPN17QP360}
-=======
-var TestParams = []ParametersLiteral{TestPN11QP54, TestPN12QP109, TestPN13QP218, TestPN14QP438, TestPN15QP880}
->>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 
 func testString(params Parameters, opname string) string {
 	return fmt.Sprintf("%s/logN=%d/logQ=%d/logP=%d/#Qi=%d/#Pi=%d",
@@ -231,38 +227,7 @@ func testEncryptor(kgen KeyGenerator, t *testing.T) {
 
 	ringQ := params.RingQ()
 
-<<<<<<< HEAD
-	t.Run(testString(params, "Encrypt/Pk/Fast/MaxLevel"), func(t *testing.T) {
-		plaintext := NewPlaintext(params, params.MaxLevel())
-		plaintext.Value.IsNTT = true
-		encryptor := NewFastEncryptor(params, pk)
-		ciphertext := NewCiphertextNTT(params, 1, plaintext.Level())
-		encryptor.Encrypt(plaintext, ciphertext)
-		require.Equal(t, plaintext.Level(), ciphertext.Level())
-		ringQ.MulCoeffsMontgomeryAndAddLvl(ciphertext.Level(), ciphertext.Value[1], sk.Value.Q, ciphertext.Value[0])
-		ringQ.InvNTTLvl(ciphertext.Level(), ciphertext.Value[0], ciphertext.Value[0])
-		require.GreaterOrEqual(t, 12+params.LogN(), log2OfInnerSum(ciphertext.Level(), ringQ, ciphertext.Value[0]))
-	})
-
-	t.Run(testString(params, "Encrypt/Pk/Fast/MinLevel"), func(t *testing.T) {
-		plaintext := NewPlaintext(params, 0)
-		plaintext.Value.IsNTT = true
-		encryptor := NewFastEncryptor(params, pk)
-		ciphertext := NewCiphertextNTT(params, 1, plaintext.Level())
-		encryptor.Encrypt(plaintext, ciphertext)
-		require.Equal(t, plaintext.Level(), ciphertext.Level())
-		ringQ.MulCoeffsMontgomeryAndAddLvl(ciphertext.Level(), ciphertext.Value[1], sk.Value.Q, ciphertext.Value[0])
-		ringQ.InvNTTLvl(ciphertext.Level(), ciphertext.Value[0], ciphertext.Value[0])
-		require.GreaterOrEqual(t, 12+params.LogN(), log2OfInnerSum(ciphertext.Level(), ringQ, ciphertext.Value[0]))
-	})
-
-	t.Run(testString(params, "Encrypt/Pk/Slow/MaxLevel"), func(t *testing.T) {
-		if params.PCount() == 0 {
-			t.Skip()
-		}
-=======
 	t.Run(testString(params, "Encrypt/Pk/MaxLevel/"), func(t *testing.T) {
->>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 		plaintext := NewPlaintext(params, params.MaxLevel())
 		plaintext.Value.IsNTT = true
 		encryptor := NewEncryptor(params, pk)
@@ -274,14 +239,7 @@ func testEncryptor(kgen KeyGenerator, t *testing.T) {
 		require.GreaterOrEqual(t, 9+params.LogN(), log2OfInnerSum(ciphertext.Level(), ringQ, ciphertext.Value[0]))
 	})
 
-<<<<<<< HEAD
-	t.Run(testString(params, "Encrypt/Pk/Slow/MinLevel"), func(t *testing.T) {
-		if params.PCount() == 0 {
-			t.Skip()
-		}
-=======
 	t.Run(testString(params, "Encrypt/Pk/MinLevel/"), func(t *testing.T) {
->>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 		plaintext := NewPlaintext(params, 0)
 		plaintext.Value.IsNTT = true
 		encryptor := NewEncryptor(params, pk)
@@ -369,35 +327,9 @@ func testKeySwitcher(kgen KeyGenerator, t *testing.T) {
 		alpha := params.PCount()
 		levelP := alpha - 1
 
-<<<<<<< HEAD
-	plaintext := NewPlaintext(params, levelQ)
-	plaintext.Value.IsNTT = true
-	encryptor := NewEncryptor(params, sk)
-	ciphertext := NewCiphertextNTT(params, 1, plaintext.Level())
-	encryptor.Encrypt(plaintext, ciphertext)
-
-	// Tests that a random polynomial decomposed is equal to its
-	// reconstruction mod each RNS
-	t.Run(testString(params, "DecomposeNTT"), func(t *testing.T) {
-
-		c2InvNTT := ringQ.NewPolyLvl(ciphertext.Level())
-		ringQ.InvNTT(ciphertext.Value[1], c2InvNTT)
-
-		coeffsBigintHaveQ := make([]*big.Int, ringQ.N)
-		coeffsBigintHaveP := make([]*big.Int, ringQ.N)
-		coeffsBigintRef := make([]*big.Int, ringQ.N)
-		coeffsBigintWant := make([]*big.Int, ringQ.N)
-
-		for i := range coeffsBigintRef {
-			coeffsBigintHaveQ[i] = new(big.Int)
-			coeffsBigintHaveP[i] = new(big.Int)
-			coeffsBigintRef[i] = new(big.Int)
-			coeffsBigintWant[i] = new(big.Int)
-=======
 		QBig := ring.NewUint(1)
 		for i := range ringQ.Modulus[:levelQ+1] {
 			QBig.Mul(QBig, ring.NewUint(ringQ.Modulus[i]))
->>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 		}
 
 		PBig := ring.NewUint(1)
@@ -453,17 +385,6 @@ func testKeySwitcher(kgen KeyGenerator, t *testing.T) {
 				ringQ.ReduceLvl(levelQ, ks.PoolDecompQP[i].Q, ks.PoolDecompQP[i].Q)
 				ringP.ReduceLvl(levelP, ks.PoolDecompQP[i].P, ks.PoolDecompQP[i].P)
 
-<<<<<<< HEAD
-	// Test that Dec(KS(Enc(ct, sk), skOut), skOut) has a small norm
-	t.Run(testString(params, "KeySwitch/Standard"), func(t *testing.T) {
-		swk := kgen.GenSwitchingKey(sk, skOut)
-		ks.SwitchKeysInPlace(ciphertext.Value[1].Level(), ciphertext.Value[1], swk, ks.Pool[1].Q, ks.Pool[2].Q)
-		ringQ.Add(ciphertext.Value[0], ks.Pool[1].Q, ciphertext.Value[0])
-		ring.CopyValues(ks.Pool[2].Q, ciphertext.Value[1])
-		ringQ.MulCoeffsMontgomeryAndAddLvl(ciphertext.Level(), ciphertext.Value[1], skOut.Value.Q, ciphertext.Value[0])
-		ringQ.InvNTTLvl(ciphertext.Level(), ciphertext.Value[0], ciphertext.Value[0])
-		require.GreaterOrEqual(t, 10+params.LogN(), log2OfInnerSum(ciphertext.Level(), ringQ, ciphertext.Value[0]))
-=======
 				ringQ.InvNTTLvl(levelQ, ks.PoolDecompQP[i].Q, tmpQ)
 				ringP.InvNTTLvl(levelP, ks.PoolDecompQP[i].P, tmpP)
 
@@ -497,7 +418,6 @@ func testKeySwitcher(kgen KeyGenerator, t *testing.T) {
 			ringQ.InvNTTLvl(ciphertext.Level(), ciphertext.Value[0], ciphertext.Value[0])
 			require.GreaterOrEqual(t, 10+params.LogN(), log2OfInnerSum(ciphertext.Level(), ringQ, ciphertext.Value[0]))
 		})
->>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 	})
 }
 
@@ -505,11 +425,7 @@ func testKeySwitchDimension(kgen KeyGenerator, t *testing.T) {
 
 	paramsLargeDim := kgen.(*keyGenerator).params
 
-<<<<<<< HEAD
-	t.Run(testString(paramsLargeDim, "KeySwitchDimension/LargeToSmall"), func(t *testing.T) {
-=======
 	t.Run(testString(paramsLargeDim, "KeySwitchDimension/"), func(t *testing.T) {
->>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 
 		if paramsLargeDim.PCount() == 0 {
 			t.Skip("#Pi is empty")
@@ -549,11 +465,7 @@ func testKeySwitchDimension(kgen KeyGenerator, t *testing.T) {
 			//Extracts Coefficients
 			ctSmallDim := NewCiphertextNTT(paramsSmallDim, 1, paramsSmallDim.MaxLevel())
 
-<<<<<<< HEAD
-	t.Run(testString(paramsLargeDim, "KeySwitchDimension/SmallToLarge"), func(t *testing.T) {
-=======
 			SwitchCiphertextRingDegreeNTT(ctLargeDim, ringQSmallDim, ringQLargeDim, ctSmallDim)
->>>>>>> 1a4f5ae6e0 ([rlwe] : revamp of encryptor)
 
 			// Decrypts with smaller dimension key
 			ringQSmallDim.MulCoeffsMontgomeryAndAddLvl(ctSmallDim.Level(), ctSmallDim.Value[1], skSmallDim.Value.Q, ctSmallDim.Value[0])

--- a/rlwe/rlwe_test.go
+++ b/rlwe/rlwe_test.go
@@ -416,7 +416,7 @@ func testKeySwitcher(kgen KeyGenerator, t *testing.T) {
 			ring.CopyValues(ks.Pool[2].Q, ciphertext.Value[1])
 			ringQ.MulCoeffsMontgomeryAndAddLvl(ciphertext.Level(), ciphertext.Value[1], skOut.Value.Q, ciphertext.Value[0])
 			ringQ.InvNTTLvl(ciphertext.Level(), ciphertext.Value[0], ciphertext.Value[0])
-			require.GreaterOrEqual(t, 10+params.LogN(), log2OfInnerSum(ciphertext.Level(), ringQ, ciphertext.Value[0]))
+			require.GreaterOrEqual(t, 11+params.LogN(), log2OfInnerSum(ciphertext.Level(), ringQ, ciphertext.Value[0]))
 		})
 	})
 }


### PR DESCRIPTION
This PR adds more ways to create copies of struct without duplicating read only data for concurrent use, similar to how it is already done for the `Evaluator`. The PR also updates and simplifies the API of `dbfv` and `dckks` packages to be more inline with the `drlwe` package.
cf. CHANGELOG.md